### PR TITLE
Fix open api spec linting errors

### DIFF
--- a/Release Candidate Messages/icar-ade-openapispec.yaml
+++ b/Release Candidate Messages/icar-ade-openapispec.yaml
@@ -98,6 +98,7 @@ paths:
           schema:
             type: string
         - name: milking-visit-id
+          description: A unique identifier for this location for the milking visit message
           in: path
           required: true
           schema:
@@ -147,6 +148,7 @@ paths:
             type: string
         - name: milking-visit-id
           in: path
+          description: A unique identifier for this location for the milking visit message
           required: true
           schema:
             type: string
@@ -195,6 +197,7 @@ paths:
             type: string
         - name: milking-visit-id
           in: path
+          description: A unique identifier for this location for the milking visit message
           required: true
           schema:
             type: string
@@ -629,6 +632,7 @@ components:
         format: date-time
     pathIcarMilkingVisitId:
       name: milking-visit-id
+      description: A unique identifier for this location for the milking visit message
       in: path
       required: true
       schema:

--- a/Release Candidate Messages/icar-ade-openapispec.yaml
+++ b/Release Candidate Messages/icar-ade-openapispec.yaml
@@ -583,8 +583,7 @@ components:
       type: object
       properties:
         data:
-#          $ref: '#/components/schemas/icarAnimalMilkingSampleType'
-          $ref: 'https://raw.githubusercontent.com/alamers/ICAR/convert-to-v3/Release%20Candidate%20Messages/JoinDataMilkSample.json'
+          $ref: 'https://raw.githubusercontent.com/adewg/ICAR/master/Release%20Candidate%20Messages/JoinDataMilkSample.json'
     quarterMilkingDuration:
       type: object
       properties:


### PR DESCRIPTION
I linted the icar-ade-openapispec yaml using the speccy linter (http://speccy.io/) which found a non-resolving url reference (see https://github.com/adewg/ICAR/issues/7) and that the milking-visit-id parameter of many methods was missing a description. Description for this parameter was populated from icarMilkingVisitResource.json