### PR TITLE
add GB/Northern Ireland schemes

### DIFF
--- a/Release Candidate Messages/icarAnimalIdSchemeCode.json
+++ b/Release Candidate Messages/icarAnimalIdSchemeCode.json
@@ -3,6 +3,8 @@
         "description": "Identifies the used scheme for an animal identification string. nl-v1 life numbers are formatted as NL 123456789. See https://www.rvo.nl/onderwerpen/agrarisch-ondernemen/dieren/dieren-registreren/runderen/oormerken-voor-runderen for more information.",
         "enum": [
           "nl.ubn",
-          "be.pen"
+          "be.pen",
+          "gb.rpa",
+          "ni.daera"
         ]
 }


### PR DESCRIPTION
Add UK cattle, sheep, and goat identification schemes for use by AHDB electronic Medicines Book for Cattle & Sheep API. Administered by the Rural Payments Agency in Great Britain and by the Department of Agriculture, Environment and Rural Affairs in Northern Ireland.