### PR TITLE
Added new stoplight/spectral linter based validation action and made minor refactoring to speccy action

### DIFF
--- a/.github/workflows/ValidateWithSpeccy.yml
+++ b/.github/workflows/ValidateWithSpeccy.yml
@@ -8,8 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
     - name: validate JSON URL scheme
       run: |
-        docker run wework/speccy lint -v -j https://raw.githubusercontent.com/${{github.repository}}/master/Release%20Candidate%20Messages/exampleUrlScheme.json
+        docker run wework/speccy lint -v -j https://raw.githubusercontent.com/${{github.repository}}/${GITHUB_REF##*/}/Release%20Candidate%20Messages/exampleUrlScheme.json
 

--- a/.github/workflows/ValidateWithSpectral.yml
+++ b/.github/workflows/ValidateWithSpectral.yml
@@ -1,0 +1,13 @@
+name: Spectral JSON Validation CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: validate JSON URL scheme
+      run: |
+        docker run stoplight/spectral lint https://raw.githubusercontent.com/${{github.repository}}/${GITHUB_REF##*/}/Release%20Candidate%20Messages/exampleUrlScheme.json -v


### PR DESCRIPTION
Added new action for JSON sheme validation based on stoplight/spectral linter.
stoplight/spectral docs https://stoplight.io/p/docs/gh/stoplightio/spectral/README.md

Modified Speccy validation action:
- removed unused checkout step
- modified exampleUrlScheme.json url to validate to exact commit branch instead of static "master".