### PR TITLE
Update exampleUrlScheme.json

### DIFF
--- a/Release Candidate Messages/exampleUrlScheme.json
+++ b/Release Candidate Messages/exampleUrlScheme.json
@@ -25,16 +25,16 @@
       "description": "Milk messages approved by the working group, waiting for a test"
     },
     {
+      "name": "release-candidate-other",
+      "description": "Other messages approved by the working group, waiting for a test"
+    },
+    {
       "name": "release-candidate-registration",
       "description": "Registration messages approved by the working group, waiting for a test"
     },
     {
       "name": "release-candidate-reproduction",
       "description": "Reproduction messages approved by the working group, waiting for a test"
-    },
-    {
-      "name": "release-candidate-other",
-      "description": "Other messages approved by the working group, waiting for a test"
     }
   ],
   "paths": {


### PR DESCRIPTION
changed the order of the tags - was causing an error in the Speccy check