### PR TITLE
Weight event changes per meeting

### DIFF
--- a/Release Candidate Messages/icarEventCoreResource.json
+++ b/Release Candidate Messages/icarEventCoreResource.json
@@ -39,7 +39,7 @@
           },
           "contemporaryGroup": {
             "type": "string",
-            "description": "For manually recorded events, record any contemporary group code that would affect statistical anlaysis."
+            "description": "For manually recorded events, record any contemporary group code that would affect statistical analysis."
           }
         }
       }

--- a/Release Candidate Messages/icarEventCoreResource.json
+++ b/Release Candidate Messages/icarEventCoreResource.json
@@ -28,6 +28,18 @@
           "location": {
             "$ref": "icarLocationIdentifierType.json",
             "description": "Unique location scheme and identifier combination."
+          },
+          "traitLabel": {
+            "$ref": "icarTraitLabelIdentifierType.json",
+            "description": "If the event represents a formal trait, identifies the recording system and trait."
+          },
+          "responsible": {
+            "type": "string",
+            "description": "Use if an observation is manually recorded, or an event is carried out or authorised by a person. SHOULD be a person object."
+          },
+          "contemporaryGroup": {
+            "type": "string",
+            "description": "For manually recorded events, record any contemporary group code that would affect statistical anlaysis."
           }
         }
       }

--- a/Release Candidate Messages/icarMassMeasureType.json
+++ b/Release Candidate Messages/icarMassMeasureType.json
@@ -1,0 +1,23 @@
+{
+    "type": "object",
+    "description": "Defines a mass or weight measurement type that can be used in events or other resources.",
+    "properties": {
+        "measurement": {
+            "type": "number",
+            "minimum": 0,
+            "description": "The weight observation, in the units specified (usually kilograms)."
+        }, 
+        "units": {
+            "$ref": "uncefactMassUnitsType.json",
+            "description": "Units specified in UN/CEFACT 3-letter form. Default if not specified is KGM."
+        },
+        "method": {
+            "$ref": "icarWeightMethodType.json",
+            "description": "The method of observation. Loadcell is the default if not specified."
+        },
+        "resolution": {
+            "type": "number",
+            "description": "The smallest measurement difference that can be discriminated given the current device settings. Specified in Units, for instance 0.5 (kilograms)."
+        }
+    }
+}

--- a/Release Candidate Messages/icarTraitLabelIdentifierType.json
+++ b/Release Candidate Messages/icarTraitLabelIdentifierType.json
@@ -1,0 +1,4 @@
+{
+    "$ref": "icarIdentifierType.json",
+    "description": "Trait identifier based on a scheme and ID."
+  }

--- a/Release Candidate Messages/icarWeightEventResource.json
+++ b/Release Candidate Messages/icarWeightEventResource.json
@@ -16,30 +16,17 @@
       {
         "properties": {
             "weight": {
-                "type": "number",
-                "minimum": 0,
-                "description": "The weight observation, in the units specified (usually kilograms)."
-            }, 
-            "units": {
-                "$ref": "uncefactMassUnitsType.json",
-                "description": "Units specified in UN/CEFACT 3-letter form. Default if not specified is KGM."
-            },
-            "method": {
-                "$ref": "icarWeightMethodType.json",
-                "description": "The method of observation. Loadcell is the default if not specified."
-            },
-            "resolution": {
-                "type": "number",
-                "description": "The smallest measurement difference that can be discriminated given the current device settings. Specified in Units, for instance 0.5 (kilograms)."
-            },
-            "device": {
-                "$ref": "icarDeviceReferenceType.json",
-                "description": "Optional information about the device used for the measurement."
-            }, 
-            "traitLabel": {
-                "$ref": "icarIdentifierType.json",
-                "description": "Identifies the intended formal trait using scheme and ID. For instance: nz.sheep.traits, LW8"
-            }
+            "$ref": "icarMassMeasureType.json",
+            "description": "The weight measurement, including units and resolution."
+          },
+          "device": {
+            "$ref": "icarDeviceReferenceType.json",
+            "description": "Optional information about the device used for the measurement."
+          }, 
+          "timeOffFeed": {
+            "type": "number",
+            "description": "Hours of curfew or withholding feed prior to weighing to standardise gut fill."
+          }
         }
       }
     ]

--- a/location-scheme.md
+++ b/location-scheme.md
@@ -31,6 +31,7 @@ We prefer that schemes are human readable even when URL-encoded. This means we p
 | de-farm-id  | farm id  | 96123456.001.001  |  Farm ID as issued by VIT. The first section correlates 1:1 with a eu-farm-id while the latter two sections specify the location in more detail. | |
 | nl-ubn  | uniek bedrijfsnummer  |   | Used in the Netherlands, used by the government (see [Uniek Bedrijfsnummer on wikipedia](https://nl.wikipedia.org/wiki/Uniek_Bedrijfsnummer). Note: this may be part of the eu-farm-id scheme?  | |
 | be-pen  | Productie-eenheidsnummer   |   | Issued by Agentschap voor Landbouw en Visserij (ALV) | |
+| au.gov.ag.pic | PIC | NA477352 | Australian farm property identifier code. Issued by each State's department of agriculture. |
 
 ## Milk tank id's
 | id  | name  | example| region & issuing party  | RegEx | 


### PR DESCRIPTION
I've made the following changes:
1. Created icarMassMeasureType.json and moved the weight measurement, units, and resolution to this file. This way other weights can use the same type.
2. Created icarTraitLabelIdentifierType.json so trait identifiers (tags of the formal or traditional recording scheme label for an observation) can be used more widely.
3. Put traitLabel and "responsible" (previously "operator") and "contemporaryGroup" into the icarEventCoreResource.json so they are available for other events.
4. Added timeOffFeed to the weight event.
5. Added Australian PIC (property code) to location-scheme.md, having discussed this with Integrity Systems Company (NLIS), Australia.