### PR TITLE
fixed typo in pregnancy method enum

### DIFF
--- a/enums/icarReproPregnancyMethodType.json
+++ b/enums/icarReproPregnancyMethodType.json
@@ -4,7 +4,7 @@
   "type": "string",
 
   "enum": [
-    "Ecography",
+    "Echography",
     "Palpation",
     "Blood",
     "Milk",


### PR DESCRIPTION
See https://github.com/adewg/ICAR/issues/90.