### PR TITLE
Merge code generation corrections from Develop into ADE-1

### DIFF
--- a/collections/icarResourceCollection.json
+++ b/collections/icarResourceCollection.json
@@ -49,10 +49,6 @@
           "description": "Link to the last page of the collection, if any. Link relation: last."
         }
       }
-    },
-    "member": {
-      "type": "array",
-      "items": {}
     }
   }
 }

--- a/resources/icarMilkingDryOffEventResource.json
+++ b/resources/icarMilkingDryOffEventResource.json
@@ -3,11 +3,6 @@
 
   "allOf": [{
       "$ref": "../resources/icarEventCoreResource.json"
-    },
-    {
-      "type": "object",
-
-      "properties": {}
     }
   ]
 }

--- a/resources/icarReproAbortionEventResource.json
+++ b/resources/icarReproAbortionEventResource.json
@@ -3,11 +3,6 @@
 
   "allOf": [{
       "$ref": "../resources/icarEventCoreResource.json"
-    },
-    {
-      "type": "object",
-      
-      "properties": {}
     }
   ]
 }


### PR DESCRIPTION
These corrections improve code generation and do not change the fundamental definitions in the ADE-1 branch or introduce breaking changes for implementers.

1.  Empty inline schemas are removed from icarMilkingDryOffEventResource and icarReproAbortionEventResource 
2. The abstract property "member" is removed from icarResourceCollection and MUST be implemented in concrete collections to provide the array of member objects. 

This closes #100 