### PR TITLE
Fixed a typo in icarLocationResource.json

### DIFF
--- a/resources/icarLocationResource.json
+++ b/resources/icarLocationResource.json
@@ -2,8 +2,9 @@
   "description": "An  location scheme / location id combinations.",
 
   "allOf": [{
-      "$ref": "./icarResource.json",
-    }, {
+      "$ref": "./icarResource.json"
+    }, 
+    {
       "type": "object",
 
       "required": [

--- a/resources/icarLocationResource.json
+++ b/resources/icarLocationResource.json
@@ -1,8 +1,9 @@
 {
   "description": "An  location scheme / location id combinations.",
 
-  "allOf": [{
-      "$ref": "./icarResource.json"
+  "allOf": [
+    {
+      "$ref": "icarResource.json"
     }, 
     {
       "type": "object",


### PR DESCRIPTION
Fixed a typo in icarLocationResource.json that I didn't spot when reviewing the original PR.