### PR TITLE
Corrected typo, added icarSetPurposeType enum.

### DIFF
--- a/enums/icarSetPurposeType.json
+++ b/enums/icarSetPurposeType.json
@@ -1,0 +1,16 @@
+{
+    "description": "Describes the purpose of a set of animals.",
+  
+    "type": "string",
+  
+    "enum": [
+      "Enclosure",
+      "Feeding",
+      "Health",
+      "Lactation",
+      "Movement",
+      "Reproduction",
+      "Session",
+      "Other"
+    ]
+  }

--- a/resources/icarAnimalSetResource.json
+++ b/resources/icarAnimalSetResource.json
@@ -1,7 +1,8 @@
 {
   "description": "Core schema for representing animal sets (often called groups or sessions).",
 
-  "allOf": [{
+  "allOf": [
+    {
       "$ref": "../resources/icarResource.json"
     },
     {
@@ -23,7 +24,7 @@
         },
         "purpose": {
           "$ref": "../enums/icarSetPurposeType.json",
-          "description": "Type of the animal set."
+          "description": "Purpose of the animal set."
         },
         "member": {
           "type": "array",

--- a/resources/icarAnimalSetResource.json
+++ b/resources/icarAnimalSetResource.json
@@ -1,5 +1,5 @@
 {
-  "description": "Core schema for representing animal sets",
+  "description": "Core schema for representing animal sets (often called groups or sessions).",
 
   "allOf": [{
       "$ref": "../resources/icarResource.json"
@@ -19,10 +19,10 @@
         },
         "name": {
           "type": "string",
-          "description": "Human readable name of the set.",
+          "description": "Human readable name of the set."
         },
-        "type": {
-          "type": "string",
+        "purpose": {
+          "$ref": "../enums/icarSetPurposeType.json",
           "description": "Type of the animal set."
         },
         "member": {

--- a/url-schemes/exampleUrlScheme.json
+++ b/url-schemes/exampleUrlScheme.json
@@ -1214,7 +1214,7 @@
           "member": [{
             "id": "6e47cd5c-2d42-4268-a665-bd17cd5fc222",
             "name": "My Barn Group",
-            "type": "BARN",
+            "purpose": "Enclosure",
             "member": [{
                 "scheme": "eu.animalId",
                 "id": "276000312312345"


### PR DESCRIPTION
Corrected typo in icarAnimalSetResource.json that was failing Spectral validation (see Actions tab).
Added icarSetPurposeType.json and defined enum for purpose of animal sets (Fixes #88 comment re type/purpose).