### PR TITLE
Hotfix: Remove oneOf: allow both courses and treatments

### DIFF
--- a/resources/icarTreatmentProgramEventResource.json
+++ b/resources/icarTreatmentProgramEventResource.json
@@ -13,36 +13,22 @@
                         "$ref": "../types/icarDiagnosisType.json"
                     },
                     "description": "Decribes the diagnosis of one or more conditions"
+                },
+                "courses": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "../types/icarMedicineCourseSummaryType.json"
+                    },
+                    "description": "Details the course of treatments at a summary (start and end date) level. The array allows for different medicines/procedures."
+                },
+                "treatments": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "../resources/icarTreatmentEventResource.json"
+                    },
+                    "description": "The list of the treatments (medicines or procedures) applied."
                 }
             }
-        },
-        {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "courses": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "../types/icarMedicineCourseSummaryType.json"
-                            },
-                            "description": "Details the course of treatments at a summary (start and end date) level. The array allows for different medicines/procedures."
-                        }
-                    }
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "treatments": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "../resources/icarTreatmentEventResource.json"
-                            },
-                            "description": "The list of the treatments (medicines or procedures) applied."
-                        }
-                    }
-                }
-            ]
         }
     ]
 } 


### PR DESCRIPTION
**Hotfix:** Simplify *icarTreatmentProgramEventResource.json* removing "oneOf".
This should fix an OpenAPI 4.x code gen problem that seems to arise from combining "allOf" and "oneOf".

This allows both **courses** and **treatments** to be specified in the same object.
I was going to add a discriminator to (e.g. hasTreatments) but thought there may be cases where a combination was valid, and on the basis that it is easier to add an attribute later than remove one, I have left it out.

Proposed for review and inclusion into ADE-1-1 branch for a hotfix (ADE 1.1.1) as it won't break current code but will enable code generation.

Fixes #158 