### PR TITLE
Fixing probable typo in test-day-results Milk Characteristics weight

### DIFF
--- a/types/icarMilkCharacteristicsType.json
+++ b/types/icarMilkCharacteristicsType.json
@@ -11,7 +11,7 @@
   "properties": {
     "characteristic": {
       "type": "string",
-      "description": "ICAR Milk Characteristics Codes and values - we have at this moment SCC, FAT, PROTEIN, LAC, UREA, BLOOD, ACETONE, BHB, LDH, PRO, AVGCOND, MAXCOND, AVGFLWR,  MAXFLWR, WEIGHT.\nThe following units have to be applied:\n\n|SCC|Somatic cell count|x1000 cells/ml|NCL\n|FAT|Fat|%|VP\n|PROTEIN|Protein|%|VP\n|LAC|Lactose|%|VP\n|UREA|Urea|mg/l|M1\n|BLOOD|Blood|true/false|A99\n|ACETONE|Acetone|mmol/l|M33\n|BHB|Beta hydroxybutyrate|mmol/l|M33\n|LDH|Lactate dehydrogenase|IU/l|\n|PRO|Progesteron|mmol/l|M33\n|AVGCOND|Average conductivity value of the milk at 25 ° C|mS/cm|H61\n|MAXCOND|Maximum conductivity value of the milk at 25 ° C|mS/cm|H61\n|AVGFLWR|Average flow rate|Kg/min|F31\n|MAXFLWR|Max flow rate|Kg/min|F31\n|WEIGHT|Weight of animal|Kg|KGM\n|PAG|Pregnancy associated glycoprotein|mmol/l|M33"
+      "description": "ICAR Milk Characteristics Codes and values - we have at this moment SCC, FAT, PROTEIN, LAC, UREA, BLOOD, ACETONE, BHB, LDH, PRO, AVGCOND, MAXCOND, AVGFLWR,  MAXFLWR, WEIGHT.\nThe following units have to be applied:\n\n|SCC|Somatic cell count|x1000 cells/ml|NCL\n|FAT|Fat|%|VP\n|PROTEIN|Protein|%|VP\n|LAC|Lactose|%|VP\n|UREA|Urea|mg/l|M1\n|BLOOD|Blood|true/false|A99\n|ACETONE|Acetone|mmol/l|M33\n|BHB|Beta hydroxybutyrate|mmol/l|M33\n|LDH|Lactate dehydrogenase|IU/l|\n|PRO|Progesteron|mmol/l|M33\n|AVGCOND|Average conductivity value of the milk at 25 ° C|mS/cm|H61\n|MAXCOND|Maximum conductivity value of the milk at 25 ° C|mS/cm|H61\n|AVGFLWR|Average flow rate|Kg/min|F31\n|MAXFLWR|Max flow rate|Kg/min|F31\n|WEIGHT|Weight of milk|Kg|KGM\n|PAG|Pregnancy associated glycoprotein|mmol/l|M33"
     },
     "value": {
       "type": "string",


### PR DESCRIPTION
## Background
The description for milking characteristics doesn't seem correct. 
`/locations/{location-scheme}/{location-id}/test-day-results` has an array of milk characteristics, and within that array it seems like there's a milk weight, but it's described as animal weight. The unit is KGM as well, which I assume is Kilograms of milk, but am not familiar with that as an actual unit.

## Side note
There's additionally `milkWeight24Hours` in the test day as well, so I'm assuming the weight in the characteristics array is for the milking being tested.

## Proposal
|WEIGHT|Weight of animal|Kg|KGM -> |WEIGHT|Weight of milk|Kg|KGM