### PR TITLE
Added new field to insemination resource + fixed "animal-sets" endpoint name in example url scheme

### DIFF
--- a/resources/icarReproInseminationEventResource.json
+++ b/resources/icarReproInseminationEventResource.json
@@ -12,6 +12,10 @@
       ],
 
       "properties": {
+        "rank": {
+          "type": "integer",
+          "description": "The rank of intervention of each AI carried out within the same reproductive cycle."
+        },
         "inseminationType": {
           "$ref": "../enums/icarReproInseminationType.json"
         },

--- a/url-schemes/exampleUrlScheme.json
+++ b/url-schemes/exampleUrlScheme.json
@@ -465,7 +465,7 @@
         }
       }
     },
-    "/locations/{location-scheme}/{location-id}/animalSets": {
+    "/locations/{location-scheme}/{location-id}/animal-sets": {
       "get": {
         "operationId": "get-animal-sets",
         "summary": "Get the animal sets for a certain location",


### PR DESCRIPTION
- added field "Rank" to "icarReproInseminationEventResource" resource (#180)
- "animalSets" endpoint name is fixed to "animal-sets" (#179)