### PR TITLE
Create stale.yml

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,19 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 90
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 30
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+  - next-major-release
+  - next-minor-release
+# Label to use when marking an issue as stale
+staleLabel: stale-issue
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
Added stale.yml with the parameters to mark 90+ day old issues as stale-issue, and to close them if no activity within a further 30 days.
In theory this will normally give us two meetings to address (plus anyone can comment or modify an issue to reactivate it, including removing the stale-issue label I believe).