### PR TITLE
Attempt to fix Spectral paths

### DIFF
--- a/.github/workflows/ValidateWithSpectral.yml
+++ b/.github/workflows/ValidateWithSpectral.yml
@@ -13,11 +13,11 @@ jobs:
     steps:
     - name: validate JSON URL scheme
       run: |
-        docker run stoplight/spectral lint {{env.URL_SCHEMES_PATH}}/exampleUrlScheme.json -r={{env.SPECTRAL_RULESET_PATH}} -v
-        docker run stoplight/spectral lint {{env.URL_SCHEMES_PATH}}/feedURLscheme.json -r={{env.SPECTRAL_RULESET_PATH}} -v
-        docker run stoplight/spectral lint {{env.URL_SCHEMES_PATH}}/healthURLScheme.json -r={{env.SPECTRAL_RULESET_PATH}} -v
-        docker run stoplight/spectral lint {{env.URL_SCHEMES_PATH}}/managementURLScheme.json -r={{env.SPECTRAL_RULESET_PATH}} -v
-        docker run stoplight/spectral lint {{env.URL_SCHEMES_PATH}}/milkURLScheme.json -r={{env.SPECTRAL_RULESET_PATH}} -v
-        docker run stoplight/spectral lint {{env.URL_SCHEMES_PATH}}/performanceURLScheme.json -r={{env.SPECTRAL_RULESET_PATH}} -v
-        docker run stoplight/spectral lint {{env.URL_SCHEMES_PATH}}/registrationURLScheme.json -r={{env.SPECTRAL_RULESET_PATH}} -v
-        docker run stoplight/spectral lint {{env.URL_SCHEMES_PATH}}/reproductionURLScheme.json -r={{env.SPECTRAL_RULESET_PATH}} -v
+        docker run stoplight/spectral lint $URL_SCHEMES_PATH/exampleUrlScheme.json -r=$SPECTRAL_RULESET_PATH -v
+        docker run stoplight/spectral lint $URL_SCHEMES_PATH/feedURLscheme.json -r=$SPECTRAL_RULESET_PATH -v
+        docker run stoplight/spectral lint $URL_SCHEMES_PATH/healthURLScheme.json -r=$SPECTRAL_RULESET_PATH -v
+        docker run stoplight/spectral lint $URL_SCHEMES_PATH/managementURLScheme.json -r=$SPECTRAL_RULESET_PATH -v
+        docker run stoplight/spectral lint $URL_SCHEMES_PATH/milkURLScheme.json -r=$SPECTRAL_RULESET_PATH -v
+        docker run stoplight/spectral lint $URL_SCHEMES_PATH/performanceURLScheme.json -r=$SPECTRAL_RULESET_PATH -v
+        docker run stoplight/spectral lint $URL_SCHEMES_PATH/registrationURLScheme.json -r=$SPECTRAL_RULESET_PATH -v
+        docker run stoplight/spectral lint $URL_SCHEMES_PATH/reproductionURLScheme.json -r=$SPECTRAL_RULESET_PATH -v


### PR DESCRIPTION
The updated spectral code needed a ruleset parameter, which Anton had attempted to specify using an environment variable to choose the appropriate ruleset for Develop/ADE-1, etc. 

This has been broken for a few months, so I am attempting to fix this. According to the documentation, you should use Linux bash syntax, not GitHub syntax when referencing environment variables in the **run** statement. So I am using `$SPECTRAL_RULESET` rather than `{{env.SPECTRAL_RULESET}}`.