### PR TITLE
Add scheme docs and well-known schemes

### DIFF
--- a/well-known/icarAnimalIdentifierType.md
+++ b/well-known/icarAnimalIdentifierType.md
@@ -1,0 +1,12 @@
+# Well-known Animal Identifier Schemes
+
+| Short URI | Resolvable URI | Description | Example | Code list or format specification |
+| --- | --- | --- | --- | --- |
+| eu.animalId | | EU-wide animal identification in terms of [ISO 11784](https://www.iso.org/standard/25881.html), where the first three decimal digits represent the [ISO 3166-1 numeric](https://en.wikipedia.org/wiki/ISO_3166-1_numeric) country code. This is a generalised form, actual specifications are set by the Competent Authority in each country. | 276000312312345 | |
+| eu.bovine | | EU-wide identification for bovine animals, with an [ISO 3166 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) prefix. This is a generalised form, actual specifications are set by the Competent Authority in each country. | NL 6802 5082 9 | |
+| icar.Interbull | | Interbull recognised animal identifiers | | https://wiki.interbull.org/public/File200 |
+| nz.digad.birthid | TBC | New Zealand dairy Birth Id | ABCD-21-1234 | |
+| nz.nait.visualid | TBC | New Zealand beef and deer visual identifier | 123456-12-1234| |
+| std.iso.11785 | | ISO 11785 compliant RFID Code Number, decimal representation with the first 3 digits containing country or manufacturer code. | 276000312312345 | https://www.iso.org/standard/25881.html |
+| usa.ain | | United States Animal Identification Number | 840003123456789 or USA0003123456789 | https://www.ecfr.gov/current/title-9/chapter-I/subchapter-C/part-86 |
+| us.bovine | | US Lifetime Herdbook number | US 123456789 | |  

--- a/well-known/icarBVBaseIdentifierType.md
+++ b/well-known/icarBVBaseIdentifierType.md
@@ -1,0 +1,4 @@
+# Well-known Breeding Value Schemes
+
+| Short URI | Resolvable URI | Organisation | Description |
+| --- | --- | --- | --- |

--- a/well-known/icarBreedIdentifierType.md
+++ b/well-known/icarBreedIdentifierType.md
@@ -1,0 +1,7 @@
+# Well-known Breed Identifier Schemes
+
+| Short URI | Resolvable URI | Description | Example | Code list or format specification |
+| --- | --- | --- | --- | --- |
+| icar.breed-2 | | ICAR 2-character breed codes. | AY | https://interbull.org/ib/icarbreedcodes |
+| icar.breed-3 | | ICAR 3-character breed codes. | RDC | https://interbull.org/ib/icarbreedcodes |
+

--- a/well-known/icarDiagnosisIdentifierType.md
+++ b/well-known/icarDiagnosisIdentifierType.md
@@ -1,0 +1,6 @@
+# Well-known Animal Health Diagnosis Code Schemes
+
+| Short URI | Resolvable URI | Description | Example | Code list or format specification |
+| --- | --- | --- | --- | --- |
+| icar.disease |  | ICAR Central Health Key for disease diagnosis. | 1.06.07.07.04. | https://www.icar.org/index.php/publications-technical-materials/amendments-recording-guidelines/diseases-codes-for-cows/ |
+| org.venomcoding | https://venomcoding.org/venom-codes/ | VeNom veterinary codes. | 22080 | http://venomcoding.org/download-codes/ |

--- a/well-known/icarFeedIdentifierType.md
+++ b/well-known/icarFeedIdentifierType.md
@@ -1,0 +1,4 @@
+# Well-known Feed Identifier Schemes
+
+| Short URI | Resolvable URI | Description | Example | Code list or format specification |
+| --- | --- | --- | --- | --- |

--- a/well-known/icarLocationIdentifierType.md
+++ b/well-known/icarLocationIdentifierType.md
@@ -1,0 +1,4 @@
+# Well-known Location (herd/farm) Identifier Schemes
+
+| Short URI | Resolvable URI | Description | Example | Code list or format specification |
+| --- | --- | --- | --- | --- |

--- a/well-known/icarMedicineIdentifierType.md
+++ b/well-known/icarMedicineIdentifierType.md
@@ -1,0 +1,4 @@
+# Well-known Medicine Registration Identifier Schemes
+
+| Short URI | Resolvable URI | Description | Example | Code list or format specification |
+| --- | --- | --- | --- | --- |

--- a/well-known/icarPropertyIdentifierType.md
+++ b/well-known/icarPropertyIdentifierType.md
@@ -1,0 +1,4 @@
+# Well-known Feed Property Identifier Schemes
+
+| Short URI | Resolvable URI | Description | Example | Code list or format specification |
+| --- | --- | --- | --- | --- |

--- a/well-known/icarTraitLabelIdentifierType.md
+++ b/well-known/icarTraitLabelIdentifierType.md
@@ -1,0 +1,5 @@
+# Well-known Trait Identifier Schemes
+
+| Short URI | Resolvable URI | Description | Example | Code list or format specification |
+| --- | --- | --- | --- | --- |
+| icar.idea |  | ICAR IDEA Trait Codes | mil | https://interbull.org/ib/idea_trait_codes |

--- a/well-known/identifier-types.md
+++ b/well-known/identifier-types.md
@@ -1,0 +1,30 @@
+# Identifier Types in the ICAR ADE Schema
+
+There are many cases where entities in the ICAR Animal Data Exchange (ADE) schema need identifiers. Animals, locations, semen straws, medicines and many other items need to be identified, and in many cases there is no single globally accepted identification scheme for an entity.
+
+Instead, ICAR ADE defines a two-part identifier, containing:
+| Component | Description |
+| --- | --- |
+| **scheme** | A URI that identifies the local, national, or other identifier scheme being used. |
+| **id** | An identifier isssued under, or in compliance with the specified scheme. |
+
+This is similar to other constructs used in Internet applications, including the use of namespaces or uniform resource name (URN) identifiers. 
+
+The scheme + id identifier combination can be used for:
+* Identifiers issued in compliance with a scheme (for instance, Interbull animal identifiers)
+* Codes defined under a recognised coding scheme (for instance, VENOM veterinary nomenclature codes)
+
+Within the ICAR ADE JSON Schema you will encounter [icarIdentifierType](../types/icarIdentifierType.json) which is the base type for identifiers. This is subclassed by reference to create identifier types for specific purposes. Subclasses do not introduce any additional fields - they merely clarify the types of identifiers that are expected in that place.
+
+Here is the list of subclassed identifiers, their purpose, and the list of well-known values for each type. You may add additional well-known values to the specific markdown files.
+| Identifier Type | Purpose | Well-known Identifiers |
+| --- | --- | --- |
+| [icarAnimalIdentifierType](../types/icarAnimalIdentifierType.json) | Issued animal identifiers. | [icarAnimalIdenfierType.md](../well-known/icarAnimalIdenfierType.md) |
+| [icarBreedIdentifierType](../types/icarBreedIdentifierType.json) | Identifier schemes for breeds. | [icarBreedIdentifierType.md](../well-known/icarBreedIdentifierType.md) |
+| [icarBVBaseIdentifierType](../types/icarBVBaseIdentifierType.json) | Identifier schemes for breeding value calculation methods or organisations. | [icarBVBaseIdentifierType.md](../well-known/icarBVBaseIdentifierType.md) | 
+| [icarDiagnosisIdentifierType](../types/icarDiagnosisIdentifierType.json) | Identifier schemes for diagnosis codes. | [icarDiagnosisIdentifierType.md](../well-known/icarDiagnosisIdentifierType.md) | 
+| [icarFeedIdentifierType](../types/icarFeedIdentifierType.json) | Identifier schemes for livestock feeds. | [icarFeedIdentifierType.md](../well-known/icarFeedIdentifierType.md) |
+| [icarLocationIdentifierType](../types/icarLocationIdentifierType.json) | Identifier schemes for herd or farm locations. | [icarLocationIdentifierType.md](../well-known/icarLocationIdentifierType.md) |
+| [icarMedicineIdentifierType](../types/icarMedicineIdentifierType.json) | Identifier schemes for national medicine registration. | [icarMedicineIdentifierType.md](../well-known/icarMedicineIdentifierType.md) |
+| [icarPropertyIdentifierType](../types/icarPropertyIdentifierType.json) | Identification schemes for feed properties. | [icarPropertyIdentifierType.md](../well-known/icarPropertyIdentifierType.md) |
+| [icarTraitLabelIdentifierType](../types/icarTraitLabelIdentifierType.json) | National or industry trait labels. | [icarTraitLabelIdentifierType.md](../well-known/icarTraitLabelIdentifierType.md) |

--- a/well-known/readme.md
+++ b/well-known/readme.md
@@ -1,0 +1,2 @@
+## /well-known
+This folder contains markdown files that specify well-known identifier types. There is one markdown file for each identifier type.


### PR DESCRIPTION
Add documentation in the versioned codebase for identifier types and schemes, and a markdown file to define each of the identifier schemes.

This is in response to a discussion at our meetings in May 2022, documented in #305.

Resolves #305 