### PR TITLE
Add PostalAddress to consignment origin and dest

### DIFF
--- a/types/PostalAddress.json
+++ b/types/PostalAddress.json
@@ -1,0 +1,32 @@
+{
+    "title": "PostalAddress - from schema.org",
+    "description": "An address object from schema.org (see https://schema.org/PostalAddress).",
+    "type": "object",
+  
+    "properties": {
+      "addressCountry": {
+        "description": "The country. For example, USA. You can also provide the two-letter ISO 3166-1 alpha-2 country code.",
+        "type": "string"
+      },
+      "addressLocality": {
+        "description": "The locality in which the street address is, and which is in the region. For example, Mountain View.",
+        "type": "string"
+      },
+      "addressRegion": {
+        "description": "The region in which the locality is, and which is in the country. For example, California or another appropriate first-level Administrative division",
+        "type": "string"
+      },
+      "postOfficeBoxNumber": {
+        "description": "The post office box number for PO box addresses.",
+        "type": "string"
+      },
+      "postalCode": {
+        "description": "The postal code. For example, 94043.",
+        "type": "string"
+      },
+      "streetAddress": {
+        "description": "The street address. For example, 1600 Amphitheatre Pkwy.",
+        "type": "string"
+      }
+    }
+  }

--- a/types/icarConsignmentType.json
+++ b/types/icarConsignmentType.json
@@ -1,5 +1,5 @@
 {
-  "description": "Consignment information for a movement (arrival, departure). Localised extensions allowed.",
+  "description": "Consignment information for a movement (arrival, departure).",
 
   "type": "object",
 
@@ -12,15 +12,21 @@
       "$ref": "../types/icarLocationIdentifierType.json"
     },
     "originAddress": {
-      "type": "string",
-      "description": "Origin address - should actually be a $ref to schema.org/organization."
+      "description": "Origin address for movement.",
+      "anyOf": [
+          { "type": "string" },
+          { "$ref": "../types/PostalAddress.json" }
+      ]
     },
     "destinationLocation": {
       "$ref": "../types/icarLocationIdentifierType.json"
     },
     "destinationAddress": {
-      "type": "string",
-      "description": "Destination address - should actually be a $ref to schema.org/organization."
+      "description": "Destination address for movement.",
+      "anyOf": [
+          { "type": "string" },
+          { "$ref": "../types/PostalAddress.json" }
+      ]
     },
     "loadingDateTime": {
       "$ref": "../types/icarDateTimeType.json",


### PR DESCRIPTION
Define PostalAddress from schema.org, and add it to icarConsignment's originAddress and destinationAddress. This uses "anyOf" to support backward compatibility for the simple string type. Resolves #317