### PR TITLE
Change icarStatistics value to number

### DIFF
--- a/resources/icarStatisticsResource.json
+++ b/resources/icarStatisticsResource.json
@@ -7,8 +7,8 @@
     "id",
     "location",
     "purpose",
-    "startDate",
-    "endDate",
+    "dateFrom",
+    "dateTo",
     "group",
     "statistics"
   ],

--- a/types/icarStatisticsType.json
+++ b/types/icarStatisticsType.json
@@ -15,7 +15,8 @@
       "$ref": "../enums/icarAggregationType.json"
     },
     "value": { 
-      "type": "double",
+      "type": "number",
+      "format": "double",
       "nullable": true,
       "description": "The value of the metric."
     }


### PR DESCRIPTION
changed to "type": "number", "format": "double", as "double" is not a valid JSON Schema type. Discovered from Speccy validation error in PR #330