### PR TITLE
Add group weigh event

### DIFF
--- a/collections/icarGroupTreatmentEventCollection.json
+++ b/collections/icarGroupTreatmentEventCollection.json
@@ -1,0 +1,21 @@
+{
+    "description": "Represents a collection of group health treatment events. Based on icarResourceCollection to provide paging etc.",
+  
+    "allOf": [{
+        "$ref": "../collections/icarResourceCollection.json"
+      },
+      {
+        "type": "object",
+        
+        "properties": {
+          "member": {
+            "type": "array",
+            "items": {
+              "$ref": "../resources/icarGroupTreatmentEventResource.json"
+            },
+            "description": "Provides the array of objects, in this case weighing events."
+          }
+        }
+      }
+    ]
+  }

--- a/collections/icarGroupWeightEventCollection.json
+++ b/collections/icarGroupWeightEventCollection.json
@@ -1,0 +1,21 @@
+{
+    "description": "Represents a collection of group weighing events. Based on icarResourceCollection to provide paging etc.",
+  
+    "allOf": [{
+        "$ref": "../collections/icarResourceCollection.json"
+      },
+      {
+        "type": "object",
+        
+        "properties": {
+          "member": {
+            "type": "array",
+            "items": {
+              "$ref": "../resources/icarGroupWeightEventResource.json"
+            },
+            "description": "Provides the array of objects, in this case weighing events."
+          }
+        }
+      }
+    ]
+  }

--- a/resources/icarGroupWeightEventResource.json
+++ b/resources/icarGroupWeightEventResource.json
@@ -1,0 +1,47 @@
+{
+    "description": "The Group Weight event records liveweight observations for a group of animals",
+    "allOf": [
+        {
+            "$ref": "../resources/icarGroupEventCoreResource.json"
+        },
+        {
+            "type": "object",
+            "properties": {
+                "units": {
+                    "$ref": "../enums/uncefactMassUnitsType.json",
+                    "description": "Units specified in UN/CEFACT 3-letter form. Default if not specified is KGM."
+                },
+                "method": {
+                    "$ref": "../enums/icarWeightMethodType.json",
+                    "description": "The method of observation. Loadcell is the default if not specified."
+                },
+                "resolution": {
+                    "type": "number",
+                    "description": "The smallest measurement difference that can be discriminated given the current device settings. Specified in Units, for instance 0.5 (kilograms)."
+                },
+                "animalWeights": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "../types/icarIndividualWeightType.json"
+                    },
+                    "description": "Array of animal id and weight pairs for animals in the event."
+                },
+                "statistics": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "../types/icarStatisticsType.json"
+                    },
+                    "description": "Array of weight statistics, namely average, sum, min, max, count, stdev"
+                },
+                "device": {
+                    "$ref": "../types/icarDeviceReferenceType.json",
+                    "description": "Optional information about the device used for the measurement."
+                },
+                "timeOffFeed": {
+                    "type": "number",
+                    "description": "Hours of curfew or withholding feed prior to weighing to standardise gut fill."
+                }
+            }
+        }
+    ]
+}

--- a/types/icarIndividualWeightType.json
+++ b/types/icarIndividualWeightType.json
@@ -1,0 +1,17 @@
+{
+    "description": "The Animal-Weight entity records a liveweight for an individual animal in a Group Weight. Either animal or weight may be null.",
+    "type": "object",
+
+    "properties": {
+        "animal": {
+            "$ref": "../types/icarAnimalIdentifierType.json",
+            "description": "Unique animal scheme and identifier combination.",
+            "nullable": true
+        },
+        "weight": {
+            "type": "number",
+            "description": "The weight measurement",
+            "nullable": true
+        }
+    }
+}

--- a/types/icarStatisticsType.json
+++ b/types/icarStatisticsType.json
@@ -15,7 +15,8 @@
       "$ref": "../enums/icarAggregationType.json"
     },
     "value": { 
-      "type": "double",
+      "type": "number",
+      "format": "double",
       "nullable": true,
       "description": "The value of the metric."
     }

--- a/url-schemes/healthURLScheme.json
+++ b/url-schemes/healthURLScheme.json
@@ -17,7 +17,7 @@
   ],
   "tags": [
     {
-      "name": "ADE-1.2-health",
+      "name": "ADE-1.3-health",
       "description": "Health messages approved by the working group"
     }
   ],
@@ -28,7 +28,7 @@
         "summary": "Get the diagnoses for a certain location",
         "description": "# Purpose\nProvides the animal health diagnoses for a location\n",
         "tags": [
-          "ADE-1.2-health"
+          "ADE-1.3-health"
         ],
         "parameters": [
           {
@@ -65,7 +65,7 @@
         "summary": "Add a single new diagnosis event",
         "description": "# Purpose  \nAllows a client to add a single animal health diagnosis event.\n",
         "tags": [
-          "ADE-1.2-health"
+          "ADE-1.3-health"
         ],
         "parameters": [
           {
@@ -133,7 +133,7 @@
         "summary": "Get the treatments for a certain location",
         "description": "# Purpose\nProvides the animal health treatments for a location\n",
         "tags": [
-          "ADE-1.2-health"
+          "ADE-1.3-health"
         ],
         "parameters": [
           {
@@ -170,7 +170,7 @@
         "summary": "Add a single new health treatment event",
         "description": "# Purpose  \nAllows a client to add a single animal health treatment event.\n",
         "tags": [
-          "ADE-1.2-health"
+          "ADE-1.3-health"
         ],
         "parameters": [
           {
@@ -214,13 +214,100 @@
         }
       }
     },
+    "/locations/{location-scheme}/{location-id}/group-treatments": {
+      "get": {
+        "operationId": "get-group-treatments",
+        "summary": "Get the group treatments for a certain location",
+        "description": "# Purpose\nProvides the group health treatments for a location\n",
+        "tags": [
+          "ADE-1.3-health"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/location-scheme"
+          },
+          {
+            "$ref": "#/components/parameters/location-id"
+          },
+          {
+            "$ref": "#/components/parameters/meta-modified-from"
+          },
+          {
+            "$ref": "#/components/parameters/meta-modified-to"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful. The response contains the treatments for the given location.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/icarGroupTreatmentEventCollection"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/default"
+          }
+        }
+      },
+      "post": {
+        "operationId": "post-single-group-treatment",
+        "summary": "Add one group health treatment event",
+        "description": "# Purpose  \nAllows a client to add one group health treatment event.\n",
+        "tags": [
+          "ADE-1.3-health"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/location-scheme"
+          },
+          {
+            "$ref": "#/components/parameters/location-id"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "description": "The health treatment event to create. \nA client MAY fill in the *ID* field with a client-generated UUID and the server MAY use this *ID*.\nIf the server does not use the client-specified *ID* field it shall issue its own *ID* for the resource.\nA client SHALL ensure that the *meta.source* and *meta.sourceId* fields are filled by the client.\n",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/icarGroupTreatmentEvent"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/icarGroupTreatmentEvent"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Created. The Location header contains the URI to the new resource."
+          },
+          "202": {
+            "description": "Accepted. The Location header contains a URI that the client can query for processing status."
+          },
+          "default": {
+            "$ref": "#/components/responses/default"
+          }
+        }
+      }
+    },
     "/locations/{location-scheme}/{location-id}/treatment-programs": {
       "get": {
         "operationId": "get-Treatment-Programs",
         "summary": "Get the treatment programs for a certain location",
         "description": "# Purpose\nProvides the animal health treatment programs for a location\n",
         "tags": [
-          "ADE-1.2-health"
+          "ADE-1.3-health"
         ],
         "parameters": [
           {
@@ -257,7 +344,7 @@
         "summary": "Add a single new health treatment programme.",
         "description": "# Purpose  \nAllows a client to add a single animal health treatment programme.\n",
         "tags": [
-          "ADE-1.2-health"
+          "ADE-1.3-health"
         ],
         "parameters": [
           {
@@ -307,7 +394,7 @@
         "summary": "Get the health-status-observed of an animal for a certain location",
         "description": "# Purpose\nProvides the animal health-status for a location\n",
         "tags": [
-          "ADE-1.2-health"
+          "ADE-1.3-health"
         ],
         "parameters": [
           {
@@ -344,7 +431,7 @@
         "summary": "Add a single new health status observed.",
         "description": "# Purpose  \nAllows a client to add a single animal health status observed.\n",
         "tags": [
-          "ADE-1.2-health"
+          "ADE-1.3-health"
         ],
         "parameters": [
           {
@@ -394,7 +481,7 @@
         "summary": "Add a single new diagnosis event",
         "description": "# Purpose  \nAllows a client to add a collection of animal health diagnosis events.\n",
         "tags": [
-          "ADE-1.2-health"
+          "ADE-1.3-health"
         ],
         "parameters": [
           {
@@ -469,7 +556,7 @@
         "summary": "Add a collection of health treatment events",
         "description": "# Purpose  \nAllows a client to add a collection of animal health treatment events.\n",
         "tags": [
-          "ADE-1.2-health"
+          "ADE-1.3-health"
         ],
         "parameters": [
           {
@@ -538,13 +625,88 @@
         }
       }
     },
+    "/batches/locations/{location-scheme}/{location-id}/group-treatments": {
+      "post": {
+        "operationId": "post-batch-group-treatments",
+        "summary": "Add a collection of group health treatment events",
+        "description": "# Purpose  \nAllows a client to add a collection of group health treatment events.\n",
+        "tags": [
+          "ADE-1.3-health"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/location-scheme"
+          },
+          {
+            "$ref": "#/components/parameters/location-id"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "description": "The collection of health treatment events to create. \nA client MAY fill in resource *Id*s with a client-generated UUID and the server MAY use these *Id*s.\nIf the server does not use the client-specified *Id* field it shall issue its own *Id*s for the resources.\nA client SHALL ensure that the *meta.source* and *meta.sourceId* fields are filled by the client.\n",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/icarGroupTreatmentEventArray"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful. The response contains a set of batch results, which may include warnings.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/batchResults"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
+            "headers": {
+              "Location": {
+                "schema": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "description": "Contains the URI to the results."
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
+            "headers": {
+              "Location": {
+                "schema": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "description": "Contains a URI to query creation status."
+              }
+            }
+          },
+          "default": {
+            "description": "The response contains a set of batch results, which may include errors and warnings.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/batchResults"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/batches/locations/{location-scheme}/{location-id}/treatment-programs": {
       "post": {
         "operationId": "post-batch-Treatment-Program",
         "summary": "Add a collection of animal health treatment program events.",
         "description": "# Purpose  \nAllows a client to add a collection of animal health treatment program events.\n",
         "tags": [
-          "ADE-1.2-health"
+          "ADE-1.3-health"
         ],
         "parameters": [
           {
@@ -619,7 +781,7 @@
         "summary": "Add new health status observed events",
         "description": "# Purpose  \nAllows a client to add a collection of animal health status observed events.\n",
         "tags": [
-          "ADE-1.2-health"
+          "ADE-1.3-health"
         ],
         "parameters": [
           {
@@ -719,6 +881,18 @@
         "type": "array",
         "items": {
           "$ref": "../resources/icarTreatmentEventResource.json"
+        }
+      },
+      "icarGroupTreatmentEvent": {
+        "$ref": "../resources/icarGroupTreatmentEventResource.json"
+      },
+      "icarGroupTreatmentEventCollection": {
+        "$ref": "../collections/icarGroupTreatmentEventCollection.json"
+      },
+      "icarGroupTreatmentEventArray": {
+        "type": "array",
+        "items": {
+          "$ref": "../resources/icarGroupTreatmentEventResource.json"
         }
       },
       "icarTreatmentProgramEvent": {

--- a/url-schemes/performanceURLScheme.json
+++ b/url-schemes/performanceURLScheme.json
@@ -127,6 +127,111 @@
                 }
             }
         },
+        "/locations/{location-scheme}/{location-id}/group-weights": {
+            "get": {
+                "operationId": "get-group-weights",
+                "summary": "Get the weights for a certain location",
+                "description": "# Purpose\nProvides the group weights for a location\n",
+                "tags": [
+                    "ADE-1.3-performance"
+                ],
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/location-scheme"
+                    },
+                    {
+                        "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/meta-modified-from"
+                    },
+                    {
+                        "$ref": "#/components/parameters/meta-modified-to"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful. The response contains the resources for the given location.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/icarGroupWeightEventCollection"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/default"
+                    }
+                }
+            },
+            "post": {
+                "operationId": "post-single-group-weight",
+                "summary": "Add a single group weight.",
+                "description": "# Purpose\nAllows a client to add a single group weight.\n",
+                "tags": [
+                    "ADE-1.3-performance"
+                ],
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/location-scheme"
+                    },
+                    {
+                        "$ref": "#/components/parameters/location-id"
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "description": "The weight to create. \nA client MAY fill in the *Id* field with a client-generated UUID and the server MAY use this *Id*.\nIf the server does not use the client-specified *ID* field it shall issue its own *ID* for the resource.\nA client SHALL ensure that the *meta.source* and *meta.sourceId* fields are filled by the client.\n",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/icarGroupWeightEventResource"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/icarGroupWeightEventResource"
+                                }
+                            }
+                        }
+                    },
+                    "201": {
+                        "description": "Created. The Location header contains the URI to the new resource.",
+                        "headers": {
+                            "Location": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "uri"
+                                },
+                                "description": "Contains the URI to the new resource."
+                            }
+                        }
+                    },
+                    "202": {
+                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
+                        "headers": {
+                            "Location": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "uri"
+                                },
+                                "description": "Contains a URI to query creation status."
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/default"
+                    }
+                }
+            }
+        },
         "/locations/{location-scheme}/{location-id}/breeding-values": {
             "get": {
                 "operationId": "get-breeding-values",
@@ -451,6 +556,81 @@
                 }
             }
         },
+        "/batches/locations/{location-scheme}/{location-id}/group-weights": {
+            "post": {
+                "operationId": "post-batch-group-weights",
+                "summary": "Add an array of weights.",
+                "description": "# Purpose \nAllows a client to add a collection of group weights.\n",
+                "tags": [
+                    "ADE-1.3-performance"
+                ],
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/location-scheme"
+                    },
+                    {
+                        "$ref": "#/components/parameters/location-id"
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "description": "The collection of group weights to create. \nA client MAY fill in resource *Id*s with a client-generated UUID and the server MAY use these *Id*s.\nIf the server does not use the client-specified *Id* field it shall issue its own *Id*s for the resources.\nA client SHALL ensure that the *meta.source* and *meta.sourceId* fields are filled by the client.\n",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/icarGroupWeightEventArray"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/batchResults"
+                                }
+                            }
+                        }
+                    },
+                    "201": {
+                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
+                        "headers": {
+                            "Location": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "uri"
+                                },
+                                "description": "Contains the URI to the results."
+                            }
+                        }
+                    },
+                    "202": {
+                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
+                        "headers": {
+                            "Location": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "uri"
+                                },
+                                "description": "Contains a URI to query creation status."
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "The response contains a set of batch results, which may include errors and warnings.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/batchResults"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/batches/locations/{location-scheme}/{location-id}/conformation-scores": {
             "post": {
                 "operationId": "post-batch-conformation-scores",
@@ -545,6 +725,18 @@
                 "type": "array",
                 "items": {
                     "$ref": "#/components/schemas/icarWeightEventResource"
+                }
+            },
+            "icarGroupWeightEventResource": {
+                "$ref": "../resources/icarGroupWeightEventResource.json"
+            },
+            "icarGroupWeightEventCollection": {
+                "$ref": "../collections/icarGroupWeightEventCollection.json"
+            },
+            "icarGroupWeightEventArray": {
+                "type": "array",
+                "items": {
+                    "$ref": "#/components/schemas/icarGroupWeightEventResource"
                 }
             },
             "icarBreedingValueCollection": {


### PR DESCRIPTION
Define a group weigh event that has statistics about a group weighing, and optionally has an array of weights/IDs (we expect mostly this will just be weights or empty, but there's a case for animal IDs if they are returned by scales for a sample of animals in a group).

Added these group events to performanceURLSchema.json

Resolves #332 

Also: Add icarGroupTreatmentCollection.json and add treatment group events to healthURLScheme.json.