### PR TITLE
Inventory classification change - fix birthPeriod validation

### DIFF
--- a/types/icarInventoryClassificationType.json
+++ b/types/icarInventoryClassificationType.json
@@ -26,8 +26,10 @@
       "description": "Primary breed defined using an identifier and scheme."
     },
     "birthPeriod": {
-      "$ref": "../types/icarDateType.json",
-      "description": "The range of birth dates. Use YYYY (all one year), YYYY-MM (one month), or two RFC3339 date-times separated by / to represent a range."
+      "type": "string",
+      "pattern": "^(([0-9]{4})|([0-9]{4}-[0-9]{2})|([0-9]{4}-[0-9]{2}-[0-9]{1,2}(Z?)(\/|--)[0-9]{4}-[0-9]{2}-[0-9]{1,2}(Z?)))$",
+      "description": "The range of birth dates. Use YYYY (all one year), YYYY-MM (one month), or two RFC3339 date-times separated by / to represent a range.",
+      "nullable": true
     },      
     "reproductiveStatus": {
       "$ref": "../enums/icarAnimalReproductionStatusType.json",

--- a/types/icarInventoryClassificationType.json
+++ b/types/icarInventoryClassificationType.json
@@ -27,7 +27,7 @@
     },
     "birthPeriod": {
       "type": "string",
-      "pattern": "^(([0-9]{4})|([0-9]{4}-[0-9]{2})|([0-9]{4}-[0-9]{2}-[0-9]{1,2}(Z?)(\/|--)[0-9]{4}-[0-9]{2}-[0-9]{1,2}(Z?)))$",
+      "pattern": "^(([0-9]{4})|([0-9]{4}-[0-1][0-9])|([0-9]{4}-[0-1][0-9]-[0-3][0-9](Z?)(\/|--)[0-9]{4}-[0-1][0-9]-[0-3][0-9](Z?)))$",
       "description": "The range of birth dates. Use YYYY (all one year), YYYY-MM (one month), or two RFC3339 date-times separated by / to represent a range.",
       "nullable": true
     },      


### PR DESCRIPTION
birthPeriod was previously specified as an icarDateType, which is half-right, because it is a date **range**.
Most validators interpret "format": "date" as an RFC3339 date, which does not allow for ranges.

Instead I have changed its type to string, and defined a pattern with a regex. If this is too complex we can ditch the regex and simply make it a string with the current description.