### PR TITLE
Merge ADE 1.3.2 changes back into Develop branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ The repository contains the JSON standard for Animal Data Exchange (ADE) produce
 
 The content of this repository is licenced using the Apache 2.0 Licence. You are encouraged to use it in your data exchanges and other applications, and also to contribute to the further development of the standard.
 
+If you have implemented previous versions of ADE, you should read the [release notes for the latest version](./ReleaseNotes.md).
+
 ## Normative Sections
 
 There are three key areas of this standard:

--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@ The content of this repository is licenced using the Apache 2.0 Licence. You are
 There are three key areas of this standard:
 
 1. The JSON Schema for Data Types: [JSON ICAR Resource Types](./resources/)
-2. The URL Schemes and Open API for location centric applications: [Application API](./url-schemes)
-3. The Generic Data API for data exchange: [Generic Data API](generic-data-api.md) 
+2. The URL Schemes and Open API for location centric applications: [Application API](./url-schemes) and [specification](./docs/location-based-api.md) for these.
+3. The Generic Data API for data exchange: [Generic Data API](./docs/generic-data-exchange-api.md) 
+
+You can also find an explanation of [how to choose between location or generic data exchange APIs](./docs/location-or-data-exchange-api.md) and [the different types of animal groups and sets](./docs/understanding-animal-groups.md) supported by the standard.
 
 ## Compliance
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,0 +1,38 @@
+# Important changes from ADE v1.2.x
+
+There are some important changes that particularly affect OpenAPI code generation between ADE 1.2.x and ADE 1.3.x and later.
+If you have implemented ADE 1.2.x or earlier, and particularly if you have used OpenAPI code generation in languages such as C# and Java, you should be aware of these changes.
+
+## Standard Discriminator for resources is now `ResourceType`
+
+The OpenAPI specification allows you to specify a "discriminator" which is used to support de-serialisation of objects from JSON text to native in-memory objects. ADE 1.2.x did not implement this consistently, primarily due to limitations in version 5.x of the common [openapi-generator tool](https://openapi-generator.tech/). 
+
+You can use a discriminator to differentiate, and help to de-serialise JSON into the correct concrete classes (a concept in object-oriented languages like C# and Java). For instance, if you read from a data source that may contain `icarResource` objects, you want to know whether the actual object being read should be instantiated as an `icarTreatmentEventResource`. 
+
+The OpenAPI rules for discriminators are:
+* The same discriminator must be used in the base class and derived classes
+* The discriminator must be declared as a string property
+* The discriminator is required
+
+We had discriminators in ADE 1.2.x, but these were not declared as string properties (only as a discriminator) and we used different discriminators for Resources (`resourceType`) and Events (`eventType`). However, events are also resources.
+
+Version 5.x of openapi-generator does not work properly if the discriminator is defined as a property and required. This does not match the OpenAPI specification.
+
+We identified this when specifying the [generic data exchange API](https://github.com/adewg/ICAR/blob/ADE-1/docs/generic-data-exchange-api.md) where being able to de-serialise objects correctly is essential. We found that some other code generators also did not correctly generate code with our previous specification of discriminators.
+
+## Corrections made in ADE 1.3.1 and ADE 1.3.2 patch releases
+* `icarWithdrawalEventResource` inherited from the incorrect event type (#347)
+* `icarStatisticsResource` had separate arrays for groups and statistics. The statistics were intended to be nested inside the groups (#353)
+* In `icarConsignmentType` `originAddress` and `destinationAddress` were originally strings, and in ADE 1.3 these were extended with `"anyOf"` to also support a schema.org `PostalAddress`. However, this broke Java implementations. We have reverted these to strings, marked them as deprecated for future releases, and added `originPostalAddress` and `destinationPostalAddress` for structured addresses. If you have started implementing 1.3, you should regenerate and check your code for 1.3.2.
+
+## Changes made in ADE 1.3.x:
+* The discriminator `resourceType` is defined as a string property in `icarResource.json`. It is therefore included in all resources, including events, using "allOf".
+* `resourceType` is a required field as is required by the OpenAPI specification.
+* `eventType` has been removed from events as it will not function properly as a discriminator.
+* `identifierType` has been removed from `icarIdentifierType.json`. Identifiers are always embedded in known contexts in JSON objects - there is never a need to make a decision when de-serialising these. Further, the only reason why identifiers are subclassed is to assist implementers to understand, find, or define the correct schemes in the [well-known identifier schemes](https://github.com/adewg/ICAR/blob/ADE-1/well-known/identifier-types.md).
+
+## Changes to your implementations from ADE 1.2.x
+* Regenerate your code using **openapi-generator 6.x** or later
+* Don't use `eventType` or `identifierType` in your implementations
+* **Let your data interchange partners know.** Most implementations prior to 1.3.x won't actually need to use the discriminator because the API context defines the type of data to be de-serialised. However, having `resourceType` as a required field may cause problems. We note that as a discriminator in the base class, it was technically always required by the OpenAPI spec, but this may not have been noted and implemented.
+* This is also a reminder to continue using the [tolerant reader pattern](https://github.com/adewg/ICAR/wiki/Design-Principles#user-content-fault-tolerance-and-extensibility) described in the ADE design principles, which helps insulate from many of these changes.

--- a/resources/icarStatisticsResource.json
+++ b/resources/icarStatisticsResource.json
@@ -13,8 +13,7 @@
         "purpose",
         "dateFrom",
         "dateTo",
-        "group",
-        "statistics"
+        "group"
       ],
 
       "properties": {

--- a/resources/icarStatisticsResource.json
+++ b/resources/icarStatisticsResource.json
@@ -1,47 +1,51 @@
 {
   "description": "Describes the statistics for a certain location.",
+  "allOf": [
+    {
+      "$ref": "../resources/icarResource.json"
+    },
+    {
+      "type": "object",
 
-  "type": "object",
+      "required": [
+        "id",
+        "location",
+        "purpose",
+        "dateFrom",
+        "dateTo",
+        "group",
+        "statistics"
+      ],
 
-  "required": [
-    "id",
-    "location",
-    "purpose",
-    "dateFrom",
-    "dateTo",
-    "group",
-    "statistics"
-  ],
-
-  "properties": {
-    "id": {
-      "type": "string",
-      "description": "Unique identifier on location level in the source system for this statistics."
-    },
-    "location": {
-      "$ref": "../types/icarLocationIdentifierType.json",
-      "description": "Unique location scheme and identifier combination."
-    },
-    "purpose": {
-      "$ref": "../enums/icarStatisticsPurposeType.json"
-    },
-    "dateFrom": {
-      "$ref": "../types/icarDateType.json"
-    },
-    "dateTo": {
-      "$ref": "../types/icarDateType.json"
-    },
-    "group": {
-      "type": "array",
-      "items": {
-        "$ref": "../types/icarStatisticsGroupType.json"
-      }
-    },
-    "statistics": {
-      "type": "array",
-      "items": {
-        "$ref": "../types/icarStatisticsType.json"
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique identifier on location level in the source system for this statistics."
+        },
+        "location": {
+          "$ref": "../types/icarLocationIdentifierType.json",
+          "description": "Unique location scheme and identifier combination."
+        },
+        "purpose": {
+          "$ref": "../enums/icarStatisticsPurposeType.json",
+          "description": "Defines the purpose for these statistics."
+        },
+        "dateFrom": {
+          "$ref": "../types/icarDateType.json",
+          "description": "The start of the period for which statistics are calculated."
+        },
+        "dateTo": {
+          "$ref": "../types/icarDateType.json",
+          "description": "The end of the period for which statistics are calculated."
+        },
+        "group": {
+          "description": "An array of groups for which statistics are calculated, each of which has statistics for that group.",
+          "type": "array",
+          "items": {
+            "$ref": "../types/icarStatisticsGroupType.json"
+          }
+        }
       }
     }
-  }
+  ]
 }

--- a/types/icarConsignmentType.json
+++ b/types/icarConsignmentType.json
@@ -13,14 +13,24 @@
     },
     "originAddress": {
       "description": "Origin address for movement.",
-      "type": "string"
+      "type": "string",
+      "deprecated": true
+    },
+    "originPostalAddress": {
+      "description": "A structured, schema.org-style address for the origin location.",
+      "$ref": "../types/PostalAddress.json"
     },
     "destinationLocation": {
       "$ref": "../types/icarLocationIdentifierType.json"
     },
     "destinationAddress": {
       "description": "Destination address for movement.",
-      "type": "string" 
+      "type": "string",
+      "deprecated": true 
+    },
+    "destinationPostalAddress": {
+      "description": "A structured, schema.org-style address for the destination location.",
+      "$ref": "../types/PostalAddress.json"
     },
     "loadingDateTime": {
       "$ref": "../types/icarDateTimeType.json",

--- a/types/icarConsignmentType.json
+++ b/types/icarConsignmentType.json
@@ -13,20 +13,14 @@
     },
     "originAddress": {
       "description": "Origin address for movement.",
-      "anyOf": [
-          { "type": "string" },
-          { "$ref": "../types/PostalAddress.json" }
-      ]
+      "type": "string"
     },
     "destinationLocation": {
       "$ref": "../types/icarLocationIdentifierType.json"
     },
     "destinationAddress": {
       "description": "Destination address for movement.",
-      "anyOf": [
-          { "type": "string" },
-          { "$ref": "../types/PostalAddress.json" }
-      ]
+      "type": "string" 
     },
     "loadingDateTime": {
       "$ref": "../types/icarDateTimeType.json",

--- a/types/icarStatisticsGroupType.json
+++ b/types/icarStatisticsGroupType.json
@@ -13,10 +13,18 @@
       "description": "Number of animals in the group."
     },
     "icarGroupSpecifier": {
+      "description": "A set of group specifiers that in combination define the animals in the group.",
       "type": "array",
       "items": {
         "$ref": "../types/icarGroupSpecifierType.json"
       }
+    },
+    "statistics": {
+      "description": "An array of statistics for this group.",
+      "type": "array",
+      "items": {
+        "$ref": "../types/icarStatisticsType.json"
+       }
     }
   }
 }

--- a/types/icarStatisticsType.json
+++ b/types/icarStatisticsType.json
@@ -1,5 +1,5 @@
 {
-  "description": "The statitics that have been calculated.",
+  "description": "The statistics that have been calculated.",
 
   "type": "object",
 
@@ -9,15 +9,14 @@
       "description": "The metric code for a specific statitics. See https://github.com/adewg/ICAR/wiki/Schemes for more info"
     },
     "unit": {
-      "$ref": "../enums/uncefactMassUnitsType.json"
+      "type": "string"
+      "description": "Eventually the unit of the metric."
     },
     "aggregation": {
       "$ref": "../enums/icarAggregationType.json"
     },
     "value": { 
       "type": "number",
-      "format": "double",
-      "nullable": true,
       "description": "The value of the metric."
     }
   }

--- a/types/icarStatisticsType.json
+++ b/types/icarStatisticsType.json
@@ -9,8 +9,8 @@
       "description": "The metric code for a specific statitics. See https://github.com/adewg/ICAR/wiki/Schemes for more info"
     },
     "unit": {
-      "type": "string"
-      "description": "Eventually the unit of the metric."
+      "type": "string",
+      "description": "The unit of the metric. This must be appropriate to the metric and UN-CEFACT unit codes should be used where possible."
     },
     "aggregation": {
       "$ref": "../enums/icarAggregationType.json"

--- a/url-schemes/milkURLScheme.json
+++ b/url-schemes/milkURLScheme.json
@@ -516,7 +516,7 @@
         },
         "/locations/{location-scheme}/{location-id}/milking-withdrawals": {
             "get": {
-                "operationId": "get existing milking-withdrawals",
+                "operationId": "get-existing-milking-withdrawals",
                 "summary": "Get the milking-withdrawals for a certain location",
                 "description": "# Purpose\nProvides the milking-withdrawals for a certain location\n",
                 "tags": [

--- a/well-known/icarMetricTypeIdentifier.md
+++ b/well-known/icarMetricTypeIdentifier.md
@@ -1,0 +1,6 @@
+# Well-known Statistics Metric Identifier Schemes
+
+| Short URI | Resolvable URI | Description | Example | Code list or format specification |
+| --- | --- | --- | --- | --- |
+| icar.org | | ICAR defined metrics - is there something available from ICAR | Milk weight | |
+| crv.nl | | CRV defined metrics - need to setup a webpage for this ... | Milk weight | |


### PR DESCRIPTION
This pull request integrates the following changes:
* Repairs to the `icarStatisticsResource` and related resources - resolves #353 
* Revert 1.3 changes to `icarConsignmentType` address fields - resolves #357 
* Added an explanation for ADE 1.3 changes around discriminators - resolves #358 
* Testing C# and Java code generation for this patch release - resolves #364 

Merging into Develop separately from the merge into ADE1.