### PR TITLE
Extensions to Consignment for animals being sent to a processor

### DIFF
--- a/types/icarConsignmentDeclarationType.json
+++ b/types/icarConsignmentDeclarationType.json
@@ -1,0 +1,16 @@
+{
+    "description": "A Consignment Declaration provides a claim or declaration, usually by the source of animals, regarding the assurance or other status of animals in the consignment.",
+
+    "type": "object",
+
+    "properties": {
+        "declarationId": {
+            "description": "Identifies the specific declaration being made using a scheme and an id.",
+            "$ref": "../types/icarDeclarationIdentifierType.json"
+        },
+        "declaredValue": {
+            "type": "string",
+            "description": "The value of the declaration."
+        }
+    }
+}

--- a/types/icarConsignmentType.json
+++ b/types/icarConsignmentType.json
@@ -20,6 +20,10 @@
       "description": "A structured, schema.org-style address for the origin location.",
       "$ref": "../types/PostalAddress.json"
     },
+    "originOrganization": {
+      "description": "The organisational details of the origin, including any necessary identifiers.",
+      "$ref": "../types/icarOrganizationType.json"
+    },
     "destinationLocation": {
       "$ref": "../types/icarLocationIdentifierType.json"
     },
@@ -31,6 +35,10 @@
     "destinationPostalAddress": {
       "description": "A structured, schema.org-style address for the destination location.",
       "$ref": "../types/PostalAddress.json"
+    },
+    "destinationOrganization": {
+      "description": "The organisational details of the destination, including any necessary identifiers.",
+      "$ref": "../types/icarOrganizationType.json"
     },
     "loadingDateTime": {
       "$ref": "../types/icarDateTimeType.json",
@@ -63,6 +71,43 @@
     "farmAssuranceReference": {
       "$ref": "../types/icarIdentifierType.json",
       "description": "Identification reference of a farm assurance operation."
+    },
+    "countConsigned": {
+      "type": "integer",
+      "description": "The number of animals despatched or consigned from the origin."
+    },
+    "countReceived": {
+      "type": "integer",
+      "description": "The number of animals received at the destination."
+    },
+    "hoursOffFeed": {
+      "type": "integer",
+      "description": "The number of hours since animals in the consignment had access to feed."
+    },
+    "hoursOffWater": {
+      "type": "integer",
+      "description": "The number of hours since animals in the consignment had access to water."
+    },
+    "references": {
+      "type": "array",
+      "description": "References associated with the consignment. These may be additional to the single transport reference (for instance, to support multi-mode transport).",
+      "items": {
+          "$ref": "../types/icarIdentifierType.json"
+      }
+    },
+    "interestedParties": {
+      "type": "array",
+      "description": "Identifies the parties and their interests in the consignment.",
+     "items": {
+          "$ref": "../types/icarInterestedPartyType.json"
+      }
+    }, 
+    "declarations": {
+      "type": "array",
+      "description": "Country, species or scheme -specific declarations for the consignment.",
+      "items": {
+          "$ref": "../types/icarConsignmentDeclarationType.json"
+      }
     }
   }
 }

--- a/types/icarDeclarationIdentifierType.json
+++ b/types/icarDeclarationIdentifierType.json
@@ -1,0 +1,11 @@
+{
+    "description": "A scheme and ID combination that uniquely identifies a claim or declaration in an assurance programme or equivalent.",
+
+    "type": "object",
+    
+    "allOf": [
+        {
+            "$ref": "../types/icarIdentifierType.json"
+        }
+    ]
+}

--- a/types/icarInterestedPartyType.json
+++ b/types/icarInterestedPartyType.json
@@ -1,0 +1,23 @@
+{
+    "description": "Identifies the interests an organization has in an entity, for example in a consignment or in a processingLot. Extends the organization object.",
+
+    "type": "object",
+
+    "allOf": [
+        {
+            "$ref": "../types/icarOrganizationType.json"
+        },
+        {
+            "required": ["interests"],
+            "properties": {
+                "interests": {
+                    "type": "array",
+                    "description": "Identifies the type of interest that the party has in a consignment or animal.",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/types/icarOrganizationIdentifierType.json
+++ b/types/icarOrganizationIdentifierType.json
@@ -1,0 +1,7 @@
+{
+  "description": "Scheme and identifier based mechanism for identifying organisations, including registered establishments and scheme memberships.",
+
+  "allOf": [{
+    "$ref": "../types/icarIdentifierType.json"
+  }]
+}

--- a/types/icarOrganizationIdentityType.json
+++ b/types/icarOrganizationIdentityType.json
@@ -1,0 +1,24 @@
+{
+    "description": "The identity of an organization in livestock supply chains. Based on a minimal set of identifiers from schema.org/organization.",
+    "type": "object",
+    "$id": "/types/icarOrganizationIdentityType",
+    "properties": {
+        "name": {
+            "type": "string",
+            "description": "Name of the organisation"
+        },
+        "leiCode": {
+            "description": "An organization identifier that uniquely identifies a legal entity as defined in ISO 17442.",
+            "type": "string"
+        },
+        "globalLocationNumber": {
+            "description": "The Global Location Number (GLN, sometimes also referred to as International Location Number or ILN) of the respective organization, person, or place. The GLN is a 13-digit number used to identify parties and physical locations.",
+            "type": "string"
+        },
+        "uri": {
+            "description": "A uniform resource identifier that is the unique reference or for this organisation, such as its web site.",
+            "type": "string",
+            "format": "uri"
+        }
+    }
+}

--- a/types/icarOrganizationIdentityType.json
+++ b/types/icarOrganizationIdentityType.json
@@ -1,7 +1,6 @@
 {
     "description": "The identity of an organization in livestock supply chains. Based on a minimal set of identifiers from schema.org/organization.",
     "type": "object",
-    "$id": "/types/icarOrganizationIdentityType",
     "properties": {
         "name": {
             "type": "string",

--- a/types/icarOrganizationType.json
+++ b/types/icarOrganizationType.json
@@ -1,6 +1,5 @@
 {
     "description": "Details for an organization that support its role in livestock systems or supply chains. Conceptually extends schema.org/organization.",
-    "$id": "/types/icarOrganizationType",
     "allOf": [
         {
             "$ref": "../types/icarOrganizationIdentityType.json"

--- a/types/icarOrganizationType.json
+++ b/types/icarOrganizationType.json
@@ -1,0 +1,37 @@
+{
+    "description": "Details for an organization that support its role in livestock systems or supply chains. Conceptually extends schema.org/organization.",
+    "$id": "/types/icarOrganizationType",
+    "allOf": [
+        {
+            "$ref": "../types/icarOrganizationIdentityType.json"
+        }
+        ,
+        {
+            "type": "object",
+            "properties": {
+                "establishmentIdentifiers": {
+                    "type": "array",
+                    "description": "Scheme and identifier combinations that provide official registrations for a business or establishment",
+                    "items": {
+                        "$ref": "../types/icarOrganizationIdentifierType.json"
+                    }
+                },
+                "address": {
+                    "$ref": "../types/PostalAddress.json",
+                    "description": "Postal address or physical address in postal format, including country. Optional as this may already be specified in a consignment."
+                },
+                "parentOrganization": {
+                    "description": "The larger organization that this organization is a sub-organization of, if any.",
+                    "$ref": "../types/icarOrganizationIdentityType.json"
+                },
+                "membershipIdentifiers": {
+                    "type": "array",
+                    "description": "Scheme and identifier combinations that identity membership in programmes",
+                    "items": {
+                        "$ref": "../types/icarOrganizationIdentifierType.json"
+                    }
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Resolves #359 
This PR defines `icarOrganizationType`, `icarOrganizationIdentityType`, and `icarOrganizationIdentifierType` (conceptually based on schema.org/organization). It then extends `icarConsignmentType`, allowing us to cater for hours without feed and water, organisations for the origin, destination, and other interested parties (e.g. owners of animals, contracted recipient of processed product), and supports multiple farm assurance declarations. It also adds an array of consignment references rather than the single transport reference to allow for multi-modal transport.