### PR TITLE
Carcass, processing lot, and carcass observations resources

### DIFF
--- a/collections/icarCarcassCollection.json
+++ b/collections/icarCarcassCollection.json
@@ -1,0 +1,21 @@
+{
+    "description": "Represents a collection of carcass resources. Based on icarResourceCollection to provide paging etc.",
+  
+    "allOf": [{
+        "$ref": "../collections/icarResourceCollection.json"
+      },
+      {
+        "type": "object",
+        
+        "properties": {
+          "member": {
+            "type": "array",
+            "items": {
+              "$ref": "../resources/icarCarcassResource.json"
+            },
+            "description": "As per JSON-LD Hydra syntax, member provides the array of objects, in this case carcasses."
+          }
+        }
+      }
+    ]
+  }

--- a/collections/icarCarcassObservationsEventCollection.json
+++ b/collections/icarCarcassObservationsEventCollection.json
@@ -1,0 +1,21 @@
+{
+    "description": "Represents a collection of carcass observation events. Based on icarResourceCollection to provide paging etc.",
+  
+    "allOf": [{
+        "$ref": "../collections/icarResourceCollection.json"
+      },
+      {
+        "type": "object",
+        
+        "properties": {
+          "member": {
+            "type": "array",
+            "items": {
+              "$ref": "../resources/icarCarcassObservationsEventResource.json"
+            },
+            "description": "As per JSON-LD Hydra syntax, member provides the array of objects, in this case carcass observation events."
+          }
+        }
+      }
+    ]
+  }

--- a/collections/icarProcessingLotCollection.json
+++ b/collections/icarProcessingLotCollection.json
@@ -1,0 +1,21 @@
+{
+    "description": "Represents a collection of carcass processing lots. Based on icarResourceCollection to provide paging etc.",
+  
+    "allOf": [{
+        "$ref": "../collections/icarResourceCollection.json"
+      },
+      {
+        "type": "object",
+        
+        "properties": {
+          "member": {
+            "type": "array",
+            "items": {
+              "$ref": "../resources/icarProcessingLotResource.json"
+            },
+            "description": "As per JSON-LD Hydra syntax, member provides the array of objects, in this case carcass processing lots."
+          }
+        }
+      }
+    ]
+  }

--- a/enums/icarCarcassPrimalType.json
+++ b/enums/icarCarcassPrimalType.json
@@ -1,0 +1,10 @@
+{
+    "description": "Indicates the primal being observed. Use Total if no primal cuts have been made.",
+    "type": "string",
+    "enum": [
+        "Total",
+        "Forequarter",
+        "Middle",
+        "Hindquarter"
+    ]
+}

--- a/enums/icarCarcassSideType.json
+++ b/enums/icarCarcassSideType.json
@@ -1,0 +1,9 @@
+{
+    "description": "Indicates the side of the carcass. Use Both for small carcasses that are not split, or before carcasses are split.",
+    "type": "string",
+    "enum": [
+        "Left",
+        "Right",
+        "Both"
+    ]
+}

--- a/enums/icarCarcassStateType.json
+++ b/enums/icarCarcassStateType.json
@@ -1,0 +1,8 @@
+{
+    "description": "Indicates whether an observation event is on the hot or cold carcass (before or after chilling).",
+    "type": "string",
+    "enum": [
+        "Hot",
+        "Cold"
+    ]
+}

--- a/enums/icarChainProcessType.json
+++ b/enums/icarChainProcessType.json
@@ -1,0 +1,8 @@
+{
+    "description": "Identifies whether observations are made before or after animals are killed.",
+    "type": "string",
+    "enum": [
+        "AnteMortem", 
+        "PostMortem"
+    ]
+}

--- a/enums/icarObservationStatusType.json
+++ b/enums/icarObservationStatusType.json
@@ -1,0 +1,11 @@
+{
+    "description": "Observations may be measured or calculated - but the measurement or calculation may fail. This describes the outcome.",
+
+    "type": "string",
+    "enum": [
+        "Measured", 
+        "NotMeasured", 
+        "Calculated", 
+        "NotCalculated"
+    ]
+}

--- a/resources/icarCarcassObservationsEventResource.json
+++ b/resources/icarCarcassObservationsEventResource.json
@@ -1,0 +1,41 @@
+{
+    "description": "An individual animal event in which a set of observations on a carcass, side or primal are recorded by an operator at a specified date-time.",
+
+    "allOf": [
+        {
+            "$ref": "../resources/icarAnimalEventCoreResource.json"
+        },
+        {
+            "type": "object",
+            "properties": {
+                "carcass": {
+                    "description": "The carcass being observed.",
+                    "$ref": "../types/icarCarcassType.json"
+                },
+                "observations": {
+                    "type": "array",
+                    "description": "The array of observations performed in this event",
+                    "items": {
+                        "$ref": "../types/icarCarcassObservationType.json"
+                    }
+                },
+                "side": {
+                    "description": "The side of the carcass observed in this event ('Both` if not split).",
+                    "$ref": "../enums/icarCarcassSideType.json"
+                },
+                "primal": {
+                    "description": "Identifies the primal being observed (`Total` if not split).",
+                    "$ref": "../enums/icarCarcassPrimalType.json"
+                },
+                "carcassState": {
+                    "description": "Indicates whether the observation event is on the hot or cold (chilled) carcass.",
+                    "$ref": "../enums/icarCarcassStateType.json"
+                },
+                "device": {
+                    "description": "Identifies the device used for performing the observations in this event.",
+                    "$ref": "../resources/icarDeviceResource.json"
+                }
+            }
+        }
+    ]
+}

--- a/resources/icarCarcassObservationsEventResource.json
+++ b/resources/icarCarcassObservationsEventResource.json
@@ -20,7 +20,7 @@
                     }
                 },
                 "side": {
-                    "description": "The side of the carcass observed in this event ('Both` if not split).",
+                    "description": "The side of the carcass observed in this event (use Both if not split).",
                     "$ref": "../enums/icarCarcassSideType.json"
                 },
                 "primal": {

--- a/resources/icarCarcassResource.json
+++ b/resources/icarCarcassResource.json
@@ -1,0 +1,12 @@
+{
+    "description": "A carcass (also called carcase) identifies a single animal which is processed at a plant. A carcass has identifying information and attributes describing the animal from the processor perspective.",
+
+    "allOf": [
+        {
+            "$ref": "../resources/icarResource.json"
+        },
+        {
+            "$ref": "../types/icarCarcassType.json"
+        }
+    ]
+}

--- a/resources/icarProcessingLotResource.json
+++ b/resources/icarProcessingLotResource.json
@@ -1,0 +1,12 @@
+{
+    "description": "A processing lot describes a group or batch of animals from a single consignment that are processed together.",
+   
+    "allOf": [
+        {
+            "$ref": "../resources/icarResource.json"
+        },
+        {
+            "$ref": "../types/icarProcessingLotType.json"
+        }
+    ]
+}

--- a/types/icarCarcassMetricIdentifierType.json
+++ b/types/icarCarcassMetricIdentifierType.json
@@ -1,0 +1,7 @@
+{
+  "description": "Scheme and identifier based mechanism for identifying carcass metrics (things observed, measured, or graded about carcasses).",
+
+  "allOf": [{
+    "$ref": "../types/icarIdentifierType.json"
+  }]
+}

--- a/types/icarCarcassMetricType.json
+++ b/types/icarCarcassMetricType.json
@@ -1,0 +1,19 @@
+{
+    "description": "Identifies a metric (observation, measure, or assessment) for a carcass that has a scheme-based identifier, plus the method used and optionally a qualfier.",
+
+    "type": "object",
+
+    "properties": {
+        "id": {
+            "$ref": "../types/icarCarcassMetricIdentifierType.json"
+        },
+        "method": {
+            "description": "The standard method used to determine the value of the metric.",
+            "type": "string"
+        },
+        "qualifier": {
+            "description": "Qualifier applied to further describe the metric (if any).",
+            "type": "string"
+        }
+    }
+}

--- a/types/icarCarcassObservationType.json
+++ b/types/icarCarcassObservationType.json
@@ -24,7 +24,7 @@
             "description": "The smallest measurement difference that can be discriminated. Specified in the units, for instance 0.5 (kilograms).",
             "type": "number"
         },
-        "qualitativeGrade": {
+        "qualitativeValue": {
             "description": "The observed value of the metric if it is a grade or other string.",
             "type": "string"
         },

--- a/types/icarCarcassObservationType.json
+++ b/types/icarCarcassObservationType.json
@@ -32,7 +32,7 @@
             "description": "The status of the observation.",
             "$ref": "../enums/icarObservationStatusType.json"
         },
-        "problemDetail": {
+        "remark": {
             "description": "The reason if there is an issue with the observation",
             "type": "string"
         }

--- a/types/icarCarcassObservationType.json
+++ b/types/icarCarcassObservationType.json
@@ -1,0 +1,40 @@
+{
+    "description": "A single observation (measurement or assessment) of a metric that is recorded for a carcase, side or primal.  The observation may have a numeric value or a qualitative grade.",
+
+    "type": "object",
+
+    "required": [
+        "metric"
+    ],
+
+    "properties": {
+        "metric": {
+            "description": "The metric observed.",
+            "$ref": "../types/icarCarcassMetricType.json"
+        },
+        "value": {
+            "description": "The observed value of the metric if it is numeric.",
+            "type": "number"
+        },
+        "units": {
+            "description": "The units in which the value is measured. UN/CEFACT units SHOULD be used for metrics where these are applicable.",
+            "type": "string"
+        },
+        "resolution": {
+            "description": "The smallest measurement difference that can be discriminated. Specified in the units, for instance 0.5 (kilograms).",
+            "type": "number"
+        },
+        "qualitativeGrade": {
+            "description": "The observed value of the metric if it is a grade or other string.",
+            "type": "string"
+        },
+        "observationStatus": {
+            "description": "The status of the observation.",
+            "$ref": "../enums/icarObservationStatusType.json"
+        },
+        "problemDetail": {
+            "description": "The reason if there is an issue with the observation",
+            "type": "string"
+        }
+    }
+}

--- a/types/icarCarcassType.json
+++ b/types/icarCarcassType.json
@@ -14,7 +14,7 @@
             "description": "The lot in which the carcass was processed. ",
             "$ref": "../types/icarProcessingLotType.json"
         },
-        "killDate": {
+        "killDateTime": {
             "description": "Date/time the animal was killed. Ideally this should be a precise date and time. However, older systems may only be able to supply the date.",
             "$ref": "../types/icarDateTimeType.json"
         },

--- a/types/icarCarcassType.json
+++ b/types/icarCarcassType.json
@@ -1,0 +1,66 @@
+{
+    "description": "A carcass (also called carcase) identifies a single animal which is processed at a plant. A carcass has identifying information and attributes describing the animal from the processor perspective.",
+
+    "type": "object",
+
+    "required": [
+        "processingLot",
+        "bodyNo",
+        "identifiers"
+    ],
+
+    "properties": {
+        "processingLot": {
+            "description": "The lot in which the carcass was processed. ",
+            "$ref": "../types/icarProcessingLotType.json"
+        },
+        "killDate": {
+            "description": "Date/time the animal was killed. Ideally this should be a precise date and time. However, older systems may only be able to supply the date.",
+            "$ref": "../types/icarDateTimeType.json"
+        },
+        "bodyNo": {
+            "type": "integer",
+            "description": "A unique identifier on the chain and kill date  assigned to the carcass by the processor."
+        },
+        "identifiers": {
+            "type": "array",
+            "description": "Identifiers for the carcass including the animal's id",
+            "items": {
+                "$ref": "../types/icarAnimalIdentifierType.json"
+            }
+        },
+        "sex": {
+            "description": "The sex of the animal as assessed at the processing plant.",
+            "$ref": "../enums/icarAnimalGenderType.json"
+        },
+        "birthDate": {
+            "description": "Assessed date of birth of the animal represented using RFC3339 (UTC).",
+            "$ref": "../types/icarDateTimeType.json"
+        },
+        "birthDateConfidence": {
+            "description": "A 3-character string representing Year, Month, and Day (YMD). Each character can have the value A (actual), E (estimate), U (unknown). e.g. AEU.",
+            "type": "string",
+            "maxLength": 3
+        },
+        "primaryBreed": {
+            "description": "Primary breed of the animal as visually categorised by the plant, represented using ICAR breed codes.",
+            "$ref": "../types/icarBreedIdentifierType.json"
+        },
+        "plantBoningRun": {
+            "description": "Allocation of the carcass to a plant boning run (if any).",
+            "type": "integer"
+        },
+        "plantBoningRunTemplate": {
+            "description": "Where a Boning Run Template is allocated by the plant, the name or ID of the template.",
+            "type": "string"
+        },
+        "destinationCode": {
+            "description": "Plant-specific destination codes that are used for company requirements and to link to boning run processing.",
+            "type": "string"
+        },
+        "refProcessorGrid": {
+            "description": "Reference to a processor-specific grid used to calculate the price paid to the producer",
+            "type": "string"
+        }
+    }
+}

--- a/types/icarCarcassType.json
+++ b/types/icarCarcassType.json
@@ -58,7 +58,7 @@
             "description": "Plant-specific destination codes that are used for company requirements and to link to boning run processing.",
             "type": "string"
         },
-        "refProcessorGrid": {
+        "processorGrid": {
             "description": "Reference to a processor-specific grid used to calculate the price paid to the producer",
             "type": "string"
         }

--- a/types/icarConsignmentDeclarationType.json
+++ b/types/icarConsignmentDeclarationType.json
@@ -1,0 +1,16 @@
+{
+    "description": "A Consignment Declaration provides a claim or declaration, usually by the source of animals, regarding the assurance or other status of animals in the consignment.",
+
+    "type": "object",
+
+    "properties": {
+        "declarationId": {
+            "description": "Identifies the specific declaration being made using a scheme and an id.",
+            "$ref": "../types/icarDeclarationIdentifierType.json"
+        },
+        "declaredValue": {
+            "type": "string",
+            "description": "The value of the declaration."
+        }
+    }
+}

--- a/types/icarConsignmentType.json
+++ b/types/icarConsignmentType.json
@@ -20,6 +20,10 @@
       "description": "A structured, schema.org-style address for the origin location.",
       "$ref": "../types/PostalAddress.json"
     },
+    "originOrganization": {
+      "description": "The organisational details of the origin, including any necessary identifiers.",
+      "$ref": "../types/icarOrganizationType.json"
+    },
     "destinationLocation": {
       "$ref": "../types/icarLocationIdentifierType.json"
     },
@@ -31,6 +35,10 @@
     "destinationPostalAddress": {
       "description": "A structured, schema.org-style address for the destination location.",
       "$ref": "../types/PostalAddress.json"
+    },
+    "destinationOrganization": {
+      "description": "The organisational details of the destination, including any necessary identifiers.",
+      "$ref": "../types/icarOrganizationType.json"
     },
     "loadingDateTime": {
       "$ref": "../types/icarDateTimeType.json",
@@ -63,6 +71,43 @@
     "farmAssuranceReference": {
       "$ref": "../types/icarIdentifierType.json",
       "description": "Identification reference of a farm assurance operation."
+    },
+    "countConsigned": {
+      "type": "integer",
+      "description": "The number of animals despatched or consigned from the origin."
+    },
+    "countReceived": {
+      "type": "integer",
+      "description": "The number of animals received at the destination."
+    },
+    "hoursOffFeed": {
+      "type": "integer",
+      "description": "The number of hours since animals in the consignment had access to feed."
+    },
+    "hoursOffWater": {
+      "type": "integer",
+      "description": "The number of hours since animals in the consignment had access to water."
+    },
+    "references": {
+      "type": "array",
+      "description": "References associated with the consignment. These may be additional to the single transport reference (for instance, to support multi-mode transport).",
+      "items": {
+          "$ref": "../types/icarIdentifierType.json"
+      }
+    },
+    "interestedParties": {
+      "type": "array",
+      "description": "Identifies the parties and their interests in the consignment.",
+     "items": {
+          "$ref": "../types/icarInterestedPartyType.json"
+      }
+    }, 
+    "declarations": {
+      "type": "array",
+      "description": "Country, species or scheme -specific declarations for the consignment.",
+      "items": {
+          "$ref": "../types/icarConsignmentDeclarationType.json"
+      }
     }
   }
 }

--- a/types/icarDeclarationIdentifierType.json
+++ b/types/icarDeclarationIdentifierType.json
@@ -1,0 +1,11 @@
+{
+    "description": "A scheme and ID combination that uniquely identifies a claim or declaration in an assurance programme or equivalent.",
+
+    "type": "object",
+    
+    "allOf": [
+        {
+            "$ref": "../types/icarIdentifierType.json"
+        }
+    ]
+}

--- a/types/icarInterestedPartyType.json
+++ b/types/icarInterestedPartyType.json
@@ -1,0 +1,23 @@
+{
+    "description": "Identifies the interests an organization has in an entity, for example in a consignment or in a processingLot. Extends the organization object.",
+
+    "type": "object",
+
+    "allOf": [
+        {
+            "$ref": "../types/icarOrganizationType.json"
+        },
+        {
+            "required": ["interests"],
+            "properties": {
+                "interests": {
+                    "type": "array",
+                    "description": "Identifies the type of interest that the party has in a consignment or animal.",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/types/icarOrganizationIdentifierType.json
+++ b/types/icarOrganizationIdentifierType.json
@@ -1,0 +1,7 @@
+{
+  "description": "Scheme and identifier based mechanism for identifying organisations, including registered establishments and scheme memberships.",
+
+  "allOf": [{
+    "$ref": "../types/icarIdentifierType.json"
+  }]
+}

--- a/types/icarOrganizationIdentityType.json
+++ b/types/icarOrganizationIdentityType.json
@@ -1,0 +1,24 @@
+{
+    "description": "The identity of an organization in livestock supply chains. Based on a minimal set of identifiers from schema.org/organization.",
+    "type": "object",
+    "$id": "/types/icarOrganizationIdentityType",
+    "properties": {
+        "name": {
+            "type": "string",
+            "description": "Name of the organisation"
+        },
+        "leiCode": {
+            "description": "An organization identifier that uniquely identifies a legal entity as defined in ISO 17442.",
+            "type": "string"
+        },
+        "globalLocationNumber": {
+            "description": "The Global Location Number (GLN, sometimes also referred to as International Location Number or ILN) of the respective organization, person, or place. The GLN is a 13-digit number used to identify parties and physical locations.",
+            "type": "string"
+        },
+        "uri": {
+            "description": "A uniform resource identifier that is the unique reference or for this organisation, such as its web site.",
+            "type": "string",
+            "format": "uri"
+        }
+    }
+}

--- a/types/icarOrganizationIdentityType.json
+++ b/types/icarOrganizationIdentityType.json
@@ -1,6 +1,7 @@
 {
     "description": "The identity of an organization in livestock supply chains. Based on a minimal set of identifiers from schema.org/organization.",
     "type": "object",
+    "required": ["name"],
     "properties": {
         "name": {
             "type": "string",

--- a/types/icarOrganizationIdentityType.json
+++ b/types/icarOrganizationIdentityType.json
@@ -1,7 +1,6 @@
 {
     "description": "The identity of an organization in livestock supply chains. Based on a minimal set of identifiers from schema.org/organization.",
     "type": "object",
-    "$id": "/types/icarOrganizationIdentityType",
     "properties": {
         "name": {
             "type": "string",

--- a/types/icarOrganizationType.json
+++ b/types/icarOrganizationType.json
@@ -1,6 +1,5 @@
 {
     "description": "Details for an organization that support its role in livestock systems or supply chains. Conceptually extends schema.org/organization.",
-    "$id": "/types/icarOrganizationType",
     "allOf": [
         {
             "$ref": "../types/icarOrganizationIdentityType.json"

--- a/types/icarOrganizationType.json
+++ b/types/icarOrganizationType.json
@@ -1,0 +1,37 @@
+{
+    "description": "Details for an organization that support its role in livestock systems or supply chains. Conceptually extends schema.org/organization.",
+    "$id": "/types/icarOrganizationType",
+    "allOf": [
+        {
+            "$ref": "../types/icarOrganizationIdentityType.json"
+        }
+        ,
+        {
+            "type": "object",
+            "properties": {
+                "establishmentIdentifiers": {
+                    "type": "array",
+                    "description": "Scheme and identifier combinations that provide official registrations for a business or establishment",
+                    "items": {
+                        "$ref": "../types/icarOrganizationIdentifierType.json"
+                    }
+                },
+                "address": {
+                    "$ref": "../types/PostalAddress.json",
+                    "description": "Postal address or physical address in postal format, including country. Optional as this may already be specified in a consignment."
+                },
+                "parentOrganization": {
+                    "description": "The larger organization that this organization is a sub-organization of, if any.",
+                    "$ref": "../types/icarOrganizationIdentityType.json"
+                },
+                "membershipIdentifiers": {
+                    "type": "array",
+                    "description": "Scheme and identifier combinations that identity membership in programmes",
+                    "items": {
+                        "$ref": "../types/icarOrganizationIdentifierType.json"
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/types/icarPlantChainType.json
+++ b/types/icarPlantChainType.json
@@ -1,0 +1,25 @@
+{
+    "description": "Identifies a processing chain in the plant.",
+
+    "type": "object",
+
+    "required": [
+        "plant",
+        "chainId"
+    ],
+
+    "properties": {
+        "plant": {
+            "description": "Identifies the plant using an Organization object.",
+            "$ref": "../types/icarOrganizationType.json"
+        },
+        "chainId": {
+            "description": "A within-plant identifier for the processing chain. This might be a name or numeric code.",
+            "type": "string"
+        },
+        "chainProcess": {
+            "description": "Whether the part of the processing chain involved is before (Ante) or after (Post) mortem.",
+            "$ref": "../enums/icarChainProcessType.json"
+        }
+    }
+}

--- a/types/icarProcessingLotType.json
+++ b/types/icarProcessingLotType.json
@@ -1,0 +1,65 @@
+{
+    "description": "A Processing Lot ('lot' for short) describes a group or batch of animals from a single consignment that are processed together.",
+
+    "type": "object",
+
+    "required": [
+        "name",
+        "chain",
+        "species"
+    ],
+
+    "properties": {
+        "id": {
+            "description": "A plant internal identifier to uniquely identify the processing lot. This should be a UUID or otherwise unique.",
+            "type": "string"
+        },
+        "name": {
+            "description": "A name or visual identifier allocated by the plant to the lot.",
+            "type": "string"
+        },
+        "chain": {
+            "description": "The processing plant and chain for this lot.",
+            "$ref": "../types/icarPlantChainType.json"
+        },
+        "killDateTime": {
+            "description": "The date and time at which killing on the lot started",
+            "$ref": "../types/icarDateTimeType.json"
+        },
+        "startBodyNumber": {
+            "description": "Ordinal of the first body or carcass in lot counting across same plant, chain and kill date",
+            "type": "integer"
+        },
+        "endBodyNumber": {
+            "description": "Ordinal of the last body or carcass in lot counting across same plant, chain and kill date",
+            "type": "integer"
+        },
+        "lotCount": {
+            "description": "The number of animals (bodies for a processor) processed in this lot.",
+            "type": "integer"
+        },
+        "targetMarket": {
+            "description": "Represents the intended market for the stock.  It is defined by the processor and may be mapped to industry grids or schedules.",
+            "type": "string"
+        },
+        "killType": {
+            "description": "The processor's internal classification code",
+            "type": "string"
+        },
+        "species": {
+            "description": "The animal species being processed in the lot",
+            "$ref": "../enums/icarAnimalSpecieType.json"
+        },
+        "consignment": {
+            "description": "Details of the inbound consignment from which animals in this lot are drawn.",
+            "$ref": "../types/icarConsignmentType.json"
+        },
+        "interestedParties": {
+            "type": "array",
+            "description": "Identifies the parties and their interests in the processing lot.",
+            "items": {
+                "$ref": "../types/icarInterestedPartyType.json"
+            }
+        }
+    }
+}

--- a/url-schemes/exampleUrlScheme.json
+++ b/url-schemes/exampleUrlScheme.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Release Candidate Messages",
     "description": "The specifications of messages which are ready for ICAR approval and release",
-    "version": "1.4",
+    "version": "1.3",
     "contact": {
       "name": "Animal Data Exchange Working Group",
       "url": "https://www.icar.org/index.php/technical-bodies/working-groups/animal-data-exchange-wg/",
@@ -44,6 +44,10 @@
     {
       "name": "ADE-1.3-reproduction",
       "description": "Reproduction messages approved by the working group"
+    },
+    {
+      "name": "ADE-1.3-carcass",
+      "description": "Carcass messages approved by the working group"
     },
     {
       "name": "ADE-1.3-scheme",
@@ -1006,7 +1010,7 @@
         "summary": "Get the embryo flushing events for a certain location",
         "description": "# Purpose\nProvides the embryo flushing events on a location\n",
         "tags": [
-          "ADE-1.4-reproduction"
+          "ADE-1.3-reproduction"
         ],
         "parameters": [{
             "$ref": "#/components/parameters/location-scheme"
@@ -2091,6 +2095,123 @@
               }
           }
       }
+    },
+    "/locations/{location-scheme}/{location-id}/carcass-processing-lots": {
+      "get": {
+          "operationId": "get-carcass-processing-lots",
+          "summary": "Get the processing lots that relate to a certain location",
+          "description": "# Purpose\nProvides the carcass processing lots relating to a location\n",
+          "tags": [
+              "ADE-1.3-carcass"
+          ],
+          "parameters": [
+              {
+                  "$ref": "#/components/parameters/location-scheme"
+              },
+              {
+                  "$ref": "#/components/parameters/location-id"
+              },
+              {
+                  "$ref": "#/components/parameters/meta-modified-from"
+              },
+              {
+                  "$ref": "#/components/parameters/meta-modified-to"
+              }
+          ],
+          "responses": {
+              "200": {
+                  "description": "Successful. The response contains the group departure events for the given location.",
+                  "content": {
+                      "application/json": {
+                          "schema": {
+                              "$ref": "#/components/schemas/icarProcessingLotCollection"
+                          }
+                      }
+                  }
+              },
+              "default": {
+                  "$ref": "#/components/responses/default"
+              }
+          }
+      }
+    },
+    "/locations/{location-scheme}/{location-id}/carcass-carcasses": {
+      "get": {
+          "operationId": "get-carcass-carcasses",
+          "summary": "Get the carcasses that relate to a certain location",
+          "description": "# Purpose\nProvides the carcasses relating to a location\n",
+          "tags": [
+              "ADE-1.3-carcass"
+          ],
+          "parameters": [
+              {
+                  "$ref": "#/components/parameters/location-scheme"
+              },
+              {
+                  "$ref": "#/components/parameters/location-id"
+              },
+              {
+                  "$ref": "#/components/parameters/meta-modified-from"
+              },
+              {
+                  "$ref": "#/components/parameters/meta-modified-to"
+              }
+          ],
+          "responses": {
+              "200": {
+                  "description": "Successful. The response contains the group departure events for the given location.",
+                  "content": {
+                      "application/json": {
+                          "schema": {
+                              "$ref": "#/components/schemas/icarCarcassCollection"
+                          }
+                      }
+                  }
+              },
+              "default": {
+                  "$ref": "#/components/responses/default"
+              }
+          }
+      }
+    },
+    "/locations/{location-scheme}/{location-id}/carcass-observations": {
+      "get": {
+          "operationId": "get-carcass-observations",
+          "summary": "Get the carcass observation events that relate to a certain location",
+          "description": "# Purpose\nProvides the carcass observation events relating to a location\n",
+          "tags": [
+              "ADE-1.3-carcass"
+          ],
+          "parameters": [
+              {
+                  "$ref": "#/components/parameters/location-scheme"
+              },
+              {
+                  "$ref": "#/components/parameters/location-id"
+              },
+              {
+                  "$ref": "#/components/parameters/meta-modified-from"
+              },
+              {
+                  "$ref": "#/components/parameters/meta-modified-to"
+              }
+          ],
+          "responses": {
+              "200": {
+                  "description": "Successful. The response contains the group departure events for the given location.",
+                  "content": {
+                      "application/json": {
+                          "schema": {
+                              "$ref": "#/components/schemas/icarCarcassObservationsEventCollection"
+                          }
+                      }
+                  }
+              },
+              "default": {
+                  "$ref": "#/components/responses/default"
+              }
+          }
+      }
     }
   },
   "components": {
@@ -2247,6 +2368,15 @@
       },
       "icarReproEmbryoFlushingEventCollection" : {
         "$ref": "../collections/icarReproEmbryoFlushingEventCollection.json"   
+      },
+      "icarProcessingLotCollection" : {
+        "$ref": "../collections/icarProcessingLotCollection.json"
+      },
+      "icarCarcassCollection" : {
+        "$ref": "../collections/icarCarcassCollection.json"
+      },
+      "icarCarcassObservationsEventCollection" : {
+        "$ref": "../collections/icarCarcassObservationsEventCollection.json"
       }
     },
     "parameters": {

--- a/url-schemes/reproductionURLScheme.json
+++ b/url-schemes/reproductionURLScheme.json
@@ -1078,7 +1078,7 @@
                 "summary": "Get the embryo flushings for a certain location",
                 "description": "# Purpose\nProvides the animal embryo flushings for a location\n",
                 "tags": [
-                    "ADE-1.4-reproduction"
+                    "ADE-1.3-reproduction"
                 ],
                 "parameters": [
                     {
@@ -1115,7 +1115,7 @@
                 "summary": "Add a single new embyro flushing.",
                 "description": "# Purpose\nAllows a client to add a single embryo flushing event.\n",
                 "tags": [
-                    "ADE-1.4-reproduction"
+                    "ADE-1.3-reproduction"
                 ],
                 "parameters": [
                     {
@@ -1142,7 +1142,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/icarReproEmbryoFlushingEventResource.json"
+                                    "$ref": "#/components/schemas/icarReproEmbryoFlushingEventResource"
                                 }
                             }
                         }
@@ -1933,7 +1933,7 @@
                 "summary": "Add an array of embryo-flushings.",
                 "description": "# Purpose \nAllows a client to add a collection of embryo-flushings.\n",
                 "tags": [
-                    "ADE-1.4-reproduction"
+                    "ADE-1.3-reproduction"
                 ],
                 "parameters": [
                     {


### PR DESCRIPTION
Add `icarCarcassResource`, `icarProcessingLot`, and `icarCarcassObservationsEvent` and supporting types and enumerations.

Resolves https://github.com/adewg/ICAR/issues/360
Resolves https://github.com/adewg/ICAR/issues/361
Resolves https://github.com/adewg/ICAR/issues/362
Resolves #363 
Resolves #155 