### PR TITLE
Correct typo in icarReproHeatEventResource.json

### DIFF
--- a/resources/icarReproHeatEventResource.json
+++ b/resources/icarReproHeatEventResource.json
@@ -47,7 +47,8 @@
           }
         },
         "deviceHeatProbability": {
-          "$ref": "integer",
+          "type": "number",
+          "format": "integer",
           "description": "The manufacturer specific indication for the certainty of the heat"
         },
         "heatReportScrSenseTime": {


### PR DESCRIPTION
Corrected the definition of `deviceHeatProbability` to be a number, format integer.