### PR TITLE
Device registration and manufacturer information

### DIFF
--- a/resources/icarDeviceResource.json
+++ b/resources/icarDeviceResource.json
@@ -51,6 +51,10 @@
     "manufacturer": {
       "$ref": "../types/icarDeviceManufacturerType.json",
       "description": "The device data as defined by the manufacturer."
+    },
+    "registration": {
+      "$ref": "../types/icarDeviceRegistrationIdentifierType.json",
+      "description": "A registration identifier for the device (most devices should eventually have a registration issued by `org.icar` or other entity)."
     }
   }
 }

--- a/types/icarDeviceReferenceType.json
+++ b/types/icarDeviceReferenceType.json
@@ -15,6 +15,14 @@
         "serial": {
           "type": "string",
           "description": "Optionally, the serial number of the device."
+        },
+        "manufacturerName": {
+          "type": "string",
+          "description": "The manufacturer of the device. This is called `manufacturerName` to distinguish it from the manufacturer-specific parameters in icarDevice."
+        },
+        "registration": {
+          "$ref": "../types/icarDeviceRegistrationIdentifierType.json",
+          "description": "A registration identifier for the device (most devices should eventually have a registration issued by `org.icar` or other entity)."
         }
       }
     }

--- a/types/icarDeviceRegistrationIdentifierType.json
+++ b/types/icarDeviceRegistrationIdentifierType.json
@@ -1,0 +1,11 @@
+{
+    "description": "A device registration scheme and ID that identifies a registered device. The primary scheme used should be `org.icar`.",
+
+    "type": "object",
+    
+    "allOf": [
+        {
+            "$ref": "../types/icarIdentifierType.json"
+        }
+    ]
+}

--- a/well-known/icarDeviceRegistrationIdentifierType.md
+++ b/well-known/icarDeviceRegistrationIdentifierType.md
@@ -1,0 +1,6 @@
+# Well-known Registration Schemes for measurement, sensing, imaging, wearable, or control devices.
+
+| Short URI | Resolvable URI | Organisation | Description |
+| --- | --- | --- | --- |
+| org.icar | https://www.icar.org/index.php/icar-recording-guidelines/#section11 | ICAR | A device registration scheme operated by ICAR. |
+


### PR DESCRIPTION
Proposed changes to device resource and device reference type:
* Add `manufacturerName` to `icarDeviceReferenceType`. Resolves #411 
* Add `registration` (a type with scheme and ID) to `icarDeviceReferenceType` and `icarDeviceResource`. Resolves #412 