### PR TITLE
Add enum for milk characteristics type

### DIFF
--- a/enums/icarMilkCharacteristicCodeType.json
+++ b/enums/icarMilkCharacteristicCodeType.json
@@ -1,0 +1,22 @@
+{
+    "description": "ICAR Milk Characteristics Codes.\nThe following units have to be applied:\n\n|SCC|Somatic cell count|x1000 cells/ml|NCL\n|FAT|Fat|%|VP\n|PROTEIN|Protein|%|VP\n|LAC|Lactose|%|VP\n|UREA|Urea|mg/l|M1\n|BLOOD|Blood|true/false|A99\n|ACETONE|Acetone|mmol/l|M33\n|BHB|Beta hydroxybutyrate|mmol/l|M33\n|LDH|Lactate dehydrogenase|IU/l|\n|PRO|Progesteron|mmol/l|M33\n|AVGCOND|Average conductivity value of the milk at 25 ° C|mS/cm|H61\n|MAXCOND|Maximum conductivity value of the milk at 25 ° C|mS/cm|H61\n|AVGFLWR|Average flow rate|Kg/min|F31\n|MAXFLWR|Max flow rate|Kg/min|F31\n|WEIGHT|Weight of animal|Kg|KGM\n|PAG|Pregnancy associated glycoprotein|mmol/l|M33",
+    "type": "string",
+    "enum": [
+        "SCC",
+        "FAT",
+        "PROTEIN",
+        "LAC",
+        "UREA",
+        "BLOOD",
+        "ACETONE",
+        "BHB",
+        "LDH",
+        "PRO",
+        "AVGCOND",
+        "MAXCOND",
+        "AVGFLWR",
+        "MAXFLWR",
+        "WEIGHT",
+        "TEMPERATURE"
+    ]
+}

--- a/types/icarMilkCharacteristicsType.json
+++ b/types/icarMilkCharacteristicsType.json
@@ -11,7 +11,7 @@
   "properties": {
     "characteristic": {
       "type": "string",
-      "description": "ICAR Milk Characteristics Codes and values: SCC, FAT, PROTEIN, LAC, UREA, BLOOD, ACETONE, BHB, LDH, PRO, AVGCOND, MAXCOND, AVGFLWR,  MAXFLWR, WEIGHT, TEMPERATURE.\nThe following units have to be applied:\n\n|SCC|Somatic cell count|x1000 cells/ml|NCL\n|FAT|Fat|%|VP\n|PROTEIN|Protein|%|VP\n|LAC|Lactose|%|VP\n|UREA|Urea|mg/l|M1\n|BLOOD|Blood|true/false|A99\n|ACETONE|Acetone|mmol/l|M33\n|BHB|Beta hydroxybutyrate|mmol/l|M33\n|LDH|Lactate dehydrogenase|IU/l|\n|PRO|Progesteron|mmol/l|M33\n|AVGCOND|Average conductivity value of the milk at 25 ° C|mS/cm|H61\n|MAXCOND|Maximum conductivity value of the milk at 25 ° C|mS/cm|H61\n|AVGFLWR|Average flow rate|Kg/min|F31\n|MAXFLWR|Max flow rate|Kg/min|F31\n|WEIGHT|Weight of animal|Kg|KGM\n|PAG|Pregnancy associated glycoprotein|mmol/l|M33"
+      "description": "Treat this field as an enum, with the list and units in https://github.com/adewg/ICAR/blob/ADE-1/enums/icarMilkCharacteristicCodeType.json."
     },
     "value": {
       "type": "string",
@@ -19,7 +19,7 @@
     },
     "unit": {
       "type": "string",
-      "description": "the defaults are described above, only use this field when differed from the default. Use UN/CEFACT codes."
+      "description": "Use the units for characteristics in https://github.com/adewg/ICAR/blob/ADE-1/enums/icarMilkCharacteristicCodeType.json. Only override when your units for a characteristic are different. Use UN/CEFACT codes."
     },
     "measuringDevice": {
       "type": "string",


### PR DESCRIPTION
Add an enumeration for milk characteristics type.

`icarMilkingVisitEventResource` and `icarMilkCharacteristicsType` are quite old and hard to understand.
Ideally milking characteristics would be managed with a scheme and a published list of characteristics with documented values.

A fallback is to make this an enum. Even there, for a few edge cases, moving from a string to an enum (with a list of valid values) might be a breaking change. Therefore, we have created the enum file and are just referencing it from the description.

Resolves #444 (sort of).