### PR TITLE
Remove use of $comment which breaks linting

### DIFF
--- a/resources/icarResource.json
+++ b/resources/icarResource.json
@@ -14,7 +14,7 @@
   "properties": {
     "resourceType" : {
       "type": "string",
-      "description": "Uniform resource identifier (URI) or shortname of the logical resourceType. The ResourceType catalog defines the set of allowed resourceTyps."
+      "description": "Uniform resource identifier (URI) or shortname of the logical resourceType. The ResourceType catalog defines the set of allowed resourceTypes."
     },
     "@self": {
       "type": "string",
@@ -22,8 +22,7 @@
     },
     "meta": {
       "$ref": "../types/icarMetaDataType.json",
-      "description": "Meta-data for the resource. Mandatory if you wish to support synchronisation.\n Systems should maintain and provide meta data if at all possible.",
-      "$comment": "ICAR ADE working group intend meta to be required in the next major release of ADE."
+      "description": "Meta-data for the resource. Mandatory if you wish to support synchronisation.\n Systems should maintain and provide meta data if at all possible.\nICAR ADE working group intend meta to be required in the next major release of ADE."
     },
     "location": {
       "$ref": "../types/icarLocationIdentifierType.json",

--- a/types/icarMetaDataType.json
+++ b/types/icarMetaDataType.json
@@ -14,8 +14,7 @@
     },
     "sourceId": {
       "type": "string",
-      "description": "Unique Id within Source (e.g. UUID, IRI, URI, or composite ID if needed) for the resource in the original source system. \n Systems should generate (if needed), store, and return sourceId if at all possible.",
-      "$comment": "ICAR ADE working group intend to make use of metadata, source and sourceId mandatory in the next major release (2.0)."
+      "description": "Unique Id within Source (e.g. UUID, IRI, URI, or composite ID if needed) for the resource in the original source system. \n Systems should generate (if needed), store, and return sourceId if at all possible.\nICAR ADE working group intend to make use of metadata, source and sourceId mandatory in the next major release (2.0)."
     },  
     "isDeleted": {
       "type": "boolean",


### PR DESCRIPTION
While `$comment` is a valid JSON schema (2020 release), it is not supported by Speccy or Spectral lint actions (perhaps because we are not yet on OpenAPI 3.1, but regardless).

It was easier just to move these $comment attributes into the accompanying text description.