### PR TITLE
Remove enum from @type

### DIFF
--- a/types/icarResourceReferenceType.json
+++ b/types/icarResourceReferenceType.json
@@ -15,8 +15,7 @@
     },
     "@type": {
       "type": "string",
-      "description": "Deprecated - use reltype. Specifies whether this is a single resource Link or a Collection.",
-      "enum": ["Link"]
+      "description": "Deprecated - use reltype. Specifies whether this is a single resource Link or a Collection."
     },
     "identifier": {
       "$ref": "../types/icarIdentifierType.json",


### PR DESCRIPTION
@type is already deprecated, but the use of "enum": ["Link"] to provide a constant value causes errors in code generation under OpenAPI 3.1. 
Fixes #451