### PR TITLE
#458 Add fedding costs and deliveried weight to consumed feed types

### DIFF
--- a/types/icarConsumedFeedType.json
+++ b/types/icarConsumedFeedType.json
@@ -1,5 +1,5 @@
 {
-  "description": "gives the consumed feed and the amount the animal was entitled to. Amounts are real weights",
+  "description": "gives the consumed feed and the amount the animal/group was entitled to. Amounts are real weights",
   "type": "object",
   "required": [
     "feedId"
@@ -12,7 +12,7 @@
     },
     "entitlement": {
       "$ref": "../types/icarFeedQuantityType.json",
-      "description": "The amount of feed the animal was entitled to receive"
+      "description": "The amount of feed the animal/group was entitled to receive"
     },
     "delivered": {
       "$ref": "../types/icarFeedQuantityType.json",
@@ -20,7 +20,7 @@
     },
     "feedConsumption": {
       "$ref": "../types/icarFeedQuantityType.json",
-      "description": "The amount of feed the animal has consumed"
+      "description": "The amount of feed the animal/group has consumed"
     },
     "dryMatterPercentage": {
       "type": "number",

--- a/types/icarConsumedFeedType.json
+++ b/types/icarConsumedFeedType.json
@@ -25,6 +25,10 @@
     "dryMatterPercentage": {
       "type": "number",
       "description": "The dry matter content of the feed provided or consumed, expressed as a percentage."
+    },
+    "totalCost": {
+      "$ref": "../types/icarCostType.json",
+      "description": "Total cost applied to this feeding. Based on the delivered or entitled amount"
     }
   }
 }

--- a/types/icarConsumedFeedType.json
+++ b/types/icarConsumedFeedType.json
@@ -14,6 +14,10 @@
       "$ref": "../types/icarFeedQuantityType.json",
       "description": "The amount of feed the animal was entitled to receive"
     },
+    "delivered": {
+      "$ref": "../types/icarFeedQuantityType.json",
+      "description": "The amount of feed the animal/group received. If not present, it can be assumed that the delivered will be equal to entitlement"
+    },
     "feedConsumption": {
       "$ref": "../types/icarFeedQuantityType.json",
       "description": "The amount of feed the animal has consumed"

--- a/types/icarConsumedRationType.json
+++ b/types/icarConsumedRationType.json
@@ -26,6 +26,10 @@
     "dryMatterPercentage": {
       "type": "number",
       "description": "The dry matter content of the ration provided or consumed, expressed as a percentage."
+    },
+    "totalCost": {
+      "$ref": "../types/icarCostType.json",
+      "description": "Total cost applied to this feeding. Based on the delivered or entitled amount"
     }
   }
 }

--- a/types/icarConsumedRationType.json
+++ b/types/icarConsumedRationType.json
@@ -1,5 +1,5 @@
 {
-  "description": "Gives the consumed amount of a mixed ration, and the amount the animal was entitled to. Amounts are real weights.",
+  "description": "Gives the consumed amount of a mixed ration, and the amount the animal/group was entitled to. Amounts are real weights.",
   
   "type": "object",
   "required": [
@@ -13,7 +13,7 @@
     },
     "entitlement": {
       "$ref": "../types/icarFeedQuantityType.json",
-      "description": "The amount of feed the animal was entitled to receive"
+      "description": "The amount of feed the animal/group was entitled to receive"
     },
     "delivered": {
       "$ref": "../types/icarFeedQuantityType.json",
@@ -21,7 +21,7 @@
     },
     "feedConsumption": {
       "$ref": "../types/icarFeedQuantityType.json",
-      "description": "The amount of feed the animal has consumed"
+      "description": "The amount of feed the animal/group has consumed"
     },
     "dryMatterPercentage": {
       "type": "number",

--- a/types/icarConsumedRationType.json
+++ b/types/icarConsumedRationType.json
@@ -15,6 +15,10 @@
       "$ref": "../types/icarFeedQuantityType.json",
       "description": "The amount of feed the animal was entitled to receive"
     },
+    "delivered": {
+      "$ref": "../types/icarFeedQuantityType.json",
+      "description": "The amount of feed the animal/group received. If not present, it can be assumed that the delivered will be equal to entitlement"
+    },
     "feedConsumption": {
       "$ref": "../types/icarFeedQuantityType.json",
       "description": "The amount of feed the animal has consumed"

--- a/types/icarCostType.json
+++ b/types/icarCostType.json
@@ -1,0 +1,22 @@
+{
+  "description": "The amount of costs",
+
+  "type": "object",
+
+  "required": [
+    "currency",
+    "value"
+  ],
+
+  "properties": {
+    "currency": {
+      "type": "string",
+      "description": "The currency of the cost expressed using the ISO 4217 3-character code (such as AUD, GBP, USD, EUR)."
+    },
+    "value": {
+      "type": "number",
+      "format": "double",
+      "description": "The costs in the units specified."
+    }
+  }
+}


### PR DESCRIPTION
Resolves #458.

- Added costType and used it to register feeding costs of feed/ration
- Added "deliverd" to be able to distinguish between entitled and actual delivered and being able to calculate the refused feed
- Updated descriptions. These types are used for indivudual animals as well as groups