### PR TITLE
Fix linting errors

### DIFF
--- a/resources/icarResponseMessageResource.json
+++ b/resources/icarResponseMessageResource.json
@@ -1,6 +1,6 @@
 {
   "description": "An RFC7807 compliant problem response for JSON APIs.",
-
+  
   "type": "object",
 
   "properties": {

--- a/url-schemes/exampleUrlScheme.json
+++ b/url-schemes/exampleUrlScheme.json
@@ -2536,7 +2536,7 @@
           "summary": "Get position observation events for animals that relate to a given location",
           "description": "# Purpose\nProvides the collection of position observation events for animals at the specified location.\n",
           "tags": [
-              "ADE-1.3-management"
+              "ADE-1.4-management"
           ],
           "parameters": [
               {
@@ -2587,7 +2587,7 @@
           "summary": "Get position observation events for groups that relate to a given location",
           "description": "# Purpose\nProvides the collection of position observation events for groups at the specified location.\n",
           "tags": [
-              "ADE-1.3-management"
+              "ADE-1.4-management"
           ],
           "parameters": [
               {

--- a/url-schemes/managementURLScheme.json
+++ b/url-schemes/managementURLScheme.json
@@ -646,7 +646,7 @@
                 "summary": "Get position observation events for animals that relate to a given location",
                 "description": "# Purpose\nProvides the collection of position observation events for animals at the specified location.\n",
                 "tags": [
-                    "ADE-1.3-management"
+                    "ADE-1.4-management"
                 ],
                 "parameters": [
                     {
@@ -695,7 +695,7 @@
                 "summary": "Add a single new animal position observation event.",
                 "description": "# Purpose\nAllows a client to add a single animal position observation event.\n",
                 "tags": [
-                    "ADE-1.3-management"
+                    "ADE-1.4-management"
                 ],
                 "parameters": [
                     {
@@ -763,7 +763,7 @@
                 "summary": "Get position observation events for groups that relate to a given location",
                 "description": "# Purpose\nProvides the collection of position observation events for groups at the specified location.\n",
                 "tags": [
-                    "ADE-1.3-management"
+                    "ADE-1.4-management"
                 ],
                 "parameters": [
                     {
@@ -812,7 +812,7 @@
                 "summary": "Add a single new group position observation event.",
                 "description": "# Purpose\nAllows a client to add a single group position observation event.\n",
                 "tags": [
-                    "ADE-1.3-management"
+                    "ADE-1.4-management"
                 ],
                 "parameters": [
                     {
@@ -1406,7 +1406,7 @@
                 "summary": "Add an array of animal position observation events.",
                 "description": "# Purpose \nAllows a client to add a collection of position observation events for individual animals.\n",
                 "tags": [
-                    "ADE-1.3-management"
+                    "ADE-1.4-management"
                 ],
                 "parameters": [
                     {
@@ -1481,7 +1481,7 @@
                 "summary": "Add an array of group position observation events.",
                 "description": "# Purpose \nAllows a client to add a collection of position observation events for groups.\n",
                 "tags": [
-                    "ADE-1.3-management"
+                    "ADE-1.4-management"
                 ],
                 "parameters": [
                     {

--- a/url-schemes/sortingURLScheme.json
+++ b/url-schemes/sortingURLScheme.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.1",
+  "openapi": "3.1.0",
   "info": {
     "title": "Sorting-related messages API Specifications",
     "description": "Specifications for messages that support livestock sorting management.",
@@ -57,7 +57,7 @@
     },
     "/locations/{location-scheme}/{location-id}/{animal-scheme}/{animal-id}/sorting": {
       "get": {
-        "operationId": "get-sorting of an animal",
+        "operationId": "get-animal-sorting",
         "summary": "Get the sorting of a certain animal for a certain site",
         "description": "# Purpose\nProvides the sorting of a certain animal\n",
         "tags": [
@@ -289,6 +289,6 @@
         }
       }
     },
-    "examples": {}
+"examples": {}
   }
 }

--- a/url-schemes/sortingURLScheme.json
+++ b/url-schemes/sortingURLScheme.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Sorting-related messages API Specifications",
     "description": "Specifications for messages that support livestock sorting management.",
-    "version": "1.3",
+    "version": "1.4",
     "contact": {
       "name": "Animal Data Exchange Working Group",
       "url": "https://www.icar.org/index.php/technical-bodies/working-groups/animal-data-exchange-wg/",
@@ -17,7 +17,7 @@
   ],
   "tags": [
     {
-      "name": "ADE-1.3-sorting",
+      "name": "ADE-1.4-sorting",
       "description": "Sorting messages approved by the working group"
     }
   ],
@@ -28,7 +28,7 @@
         "summary": "Get the sorting-sites for a certain location",
         "description": "# Purpose\nProvides the sorting-sites for a location\n",
         "tags": [
-          "ADE-1.3-sorting"
+          "ADE-1.4-sorting"
         ],
         "parameters": [
           {
@@ -61,7 +61,7 @@
         "summary": "Get the sorting of a certain animal for a certain site",
         "description": "# Purpose\nProvides the sorting of a certain animal\n",
         "tags": [
-          "ADE-1.3-sorting"
+          "ADE-1.4-sorting"
         ],
         "parameters": [
           {
@@ -98,7 +98,7 @@
         "summary": "Delete sorting for a certain animal of a location",
         "description": "# Purpose\nProvides the deletion of sorting for a location\n",
         "tags": [
-          "ADE-1.3-sorting"
+          "ADE-1.4-sorting"
         ],
         "parameters": [
           {
@@ -130,7 +130,7 @@
         "summary": "Get the known sorting-commands for all animals of a certain location",
         "description": "# Purpose\nProvides the known sorting-commands for all animals of a location\n",
         "tags": [
-          "ADE-1.3-sorting"
+          "ADE-1.4-sorting"
         ],
         "parameters": [
           {
@@ -161,7 +161,7 @@
         "summary": "Add an animal into a sorting-site.",
         "description": "# Purpose\nAllows a client to add an animal to a sorting-site",
         "tags": [
-          "ADE-1.3-sorting"
+          "ADE-1.4-sorting"
         ],
         "parameters": [
           {


### PR DESCRIPTION
We had some errors in the URL scheme files that were causing linting errors (including errors in other files).
- incorrect tags (still referring to ADE-1.3-xxx while we have updated to ADE-1.4-xxx
- a file was set to OpenAPI 3.0.1 and we have now moved the schemas to OpenAPI 3.1.0

I still need to go through the URL scheme files and ensure that all the resource types are used somewhere.