### PR TITLE
Add extended reason codes

### DIFF
--- a/resources/icarMovementDeathEventResource.json
+++ b/resources/icarMovementDeathEventResource.json
@@ -1,5 +1,5 @@
 {
-  "description": "Event for recording animal death",
+  "description": "Event for recording animal death on farm.",
 
   "allOf": [{
       "$ref": "../resources/icarAnimalEventCoreResource.json"
@@ -35,6 +35,13 @@
         "deathMethod": {
           "$ref": "../enums/icarDeathMethodType.json",
           "description": "Defines the method of death, including an accident, natural causes, or euthanised."
+        },
+        "extendedReasons": {
+          "description": "Extended reason codes why this animal has died.",
+          "type": "array",
+          "items": {
+            "$ref": "../types/icarReasonIdentifierType.json"
+          }
         }        
       }
     }

--- a/resources/icarMovementDepartureEventResource.json
+++ b/resources/icarMovementDepartureEventResource.json
@@ -1,5 +1,5 @@
 {
-  "description": "Event for recording animal departure",
+  "description": "Event for recording live animal departure.",
 
   "allOf": [{
       "$ref": "../resources/icarAnimalEventCoreResource.json"
@@ -19,6 +19,13 @@
         "consignment": {
           "$ref": "../types/icarConsignmentType.json",
           "description": "Identifies the consignment of the animal from the holding."
+        },
+        "extendedReasons": {
+          "description": "Extended reason codes why this animal has departed.",
+          "type": "array",
+          "items": {
+            "$ref": "../types/icarReasonIdentifierType.json"
+          }
         }
       }
     }

--- a/resources/icarReproDoNotBreedEventResource.json
+++ b/resources/icarReproDoNotBreedEventResource.json
@@ -11,6 +11,13 @@
           "type": ["boolean", "null"],
           "description": "Set this attribute to true if the animal should not be bred, false if it may now be bred.",
           "default": true
+        },
+        "extendedReasons": {
+          "description": "Extended reason codes why this animal should not be bred.",
+          "type": "array",
+          "items": {
+            "$ref": "../types/icarReasonIdentifierType.json"
+          }
         }
       }
     }

--- a/types/icarReasonIdentifierType.json
+++ b/types/icarReasonIdentifierType.json
@@ -1,0 +1,7 @@
+{
+  "description": "Extended reason identifier based on a scheme and ID.",
+
+  "allOf": [{
+    "$ref": "../types/icarIdentifierType.json"
+  }]
+}

--- a/well-known/icarReasonIdentifierType.md
+++ b/well-known/icarReasonIdentifierType.md
@@ -1,0 +1,6 @@
+# Well-known Extended Reason Identifier Schemes
+
+These schemes define country, region, or species-specific extended reason codes for departures, deaths, and do not breed events. If you represent a recording organisation or scheme operator, please edit and "Pull Request" this file to let others know about your extended reason code schemes.
+
+| Short URI | Resolvable URI | Description | Example | Code list or format specification |
+| --- | --- | --- | --- | --- |


### PR DESCRIPTION
Define icarReasonIdentifierType and add its well-known file for people to document their schemes.

Add an array of extended reasons to the death, departure, and do-not-breed events.

Resolves #454 
Resolves #455 