### PR TITLE
Extend enumeration uncefactDoseUnitsType.json

### DIFF
--- a/enums/uncefactDoseUnitsType.json
+++ b/enums/uncefactDoseUnitsType.json
@@ -9,6 +9,8 @@
     "MGM",
     "GRM",
     "XTU",
+    "TU",
+    "EA",
     "XVI",
     "XAR",
     "XCQ",


### PR DESCRIPTION
As raised by @cookeac in issue #487 , I have added 2 new dose units to the enumeration uncefactDoseUnitsType.json:

- EA for each for items like boluses
- TU for tube, in line with UN/CEFACT Recommendation 20