### PR TITLE
fix nullable reference

### DIFF
--- a/resources/icarAttentionEventResource.json
+++ b/resources/icarAttentionEventResource.json
@@ -12,8 +12,10 @@
 
         "properties": {
             "alertEndDateTime": {
-                "type": ["string", "null"],
-                "$ref": "../types/icarDateTimeType.json",
+                 "anyOf": [
+                     {"type": "null"},
+                     {"$ref": "../types/icarDateTimeType.json"}
+                 ],
                 "description": "RFC3339 date time that represents the end time of an alert (start time is the eventDateTime) if it has ended."
             },
             "category": {

--- a/resources/icarProgenyDetailsResource.json
+++ b/resources/icarProgenyDetailsResource.json
@@ -24,7 +24,11 @@
         "alternativeIdentifiers": {
           "anyOf": [
               {"type": "null"},
-              {"$ref": "../types/icarAnimalIdentifierType.json"}
+              {"type": "array",
+                  "items": {
+                      "$ref": "../types/icarAnimalIdentifierType.json"
+                  }
+              }  
           ],
           "description": "Alternative identifiers for the animal. Here, also temporary identifiers, e.g. transponders or animal numbers, can be listed."
         },

--- a/resources/icarProgenyDetailsResource.json
+++ b/resources/icarProgenyDetailsResource.json
@@ -16,18 +16,16 @@
       "properties": {
         "identifier": {
           "description": "Unique animal scheme and identifier combination.",
-          "type": ["object", "null"],
-          "allOf": [
-            {
-              "$ref": "../types/icarAnimalIdentifierType.json"
-            }
+          "anyOf": [
+              {"type": "null"},
+              {"$ref": "../types/icarAnimalIdentifierType.json"}
           ]
         },
         "alternativeIdentifiers": {
-          "type": ["array","null"],
-          "items": {
-            "$ref": "../types/icarAnimalIdentifierType.json"
-          },
+          "anyOf": [
+              {"type": "null"},
+              {"$ref": "../types/icarAnimalIdentifierType.json"}
+          ],
           "description": "Alternative identifiers for the animal. Here, also temporary identifiers, e.g. transponders or animal numbers, can be listed."
         },
         "specie": {
@@ -39,7 +37,10 @@
           "description": "Gender of the animal."
         },
         "managementTag": {
-          "type": ["string", "null"],
+          "anyOf": [
+              {"type": "null"},
+              {"type": "string"}
+          ],
           "description": "The identifier used by the farmer in day to day operations. In many cases this could be the animal number."
         },
         "name": {
@@ -52,38 +53,30 @@
         },
         "taggingDate": {
           "description": "Progeny tagging date in RFC3339 UTC (see https://ijmacd.github.io/rfc3339-iso8601/ for format guidance).",
-          "type": ["string", "null"],
-          "allOf": [
-            {
-              "$ref": "../types/icarDateTimeType.json"
-            }
+          "anyOf": [
+              {"type": "null"},
+              {"$ref": "../types/icarDateTimeType.json"}
           ]
         },
         "birthStatus": {
           "description": "Birth status of the progeny.",
-          "type": ["string", "null"],
-          "allOf": [
-            {
-              "$ref": "../enums/icarParturitionBirthStatusType.json"
-            }
+          "anyOf": [
+              {"type": "null"},
+              {"$ref": "../enums/icarParturitionBirthStatusType.json"}
           ]
         },
         "birthSize": {
           "description": "Size of the progeny.",
-          "type": ["string", "null"],
-          "allOf": [
-            {
-              "$ref": "../enums/icarParturitionBirthSizeType.json"
-            }
+          "anyOf": [
+              {"type": "null"},
+              {"$ref": "../enums/icarParturitionBirthSizeType.json"}
           ]
         },
         "birthWeight": {
           "description": "Weight of the progeny.",
-          "type": ["object", "null"],
-          "allOf": [
-            {
-              "$ref": "../types/icarMassMeasureType.json"
-            }
+          "anyOf": [
+              {"type": "null"},
+              {"$ref": "../types/icarMassMeasureType.json"}
           ]
         }
       }

--- a/types/icarMetaDataType.json
+++ b/types/icarMetaDataType.json
@@ -26,11 +26,9 @@
     },
     "created": {
       "description": "RFC3339 UTC date/time of creation (see https://ijmacd.github.io/rfc3339-iso8601/ for format guidance).",
-      "type": ["string", "null"],
-      "allOf": [
-        {
-          "$ref": "../types/icarDateTimeType.json"
-        }
+      "anyOf": [
+        {"type": "null"},
+        {"$ref": "../types/icarDateTimeType.json"}
       ]
     },
     "creator": {
@@ -39,20 +37,16 @@
     },
     "validFrom": {
       "description": "RFC3339 UTC start of period when the resource is valid (see https://ijmacd.github.io/rfc3339-iso8601/ for format guidance).",
-      "type": ["string", "null"],
-      "allOf": [
-        {
-          "$ref": "../types/icarDateTimeType.json"
-        }
+      "anyOf": [
+        {"type": "null"},
+        {"$ref": "../types/icarDateTimeType.json"}
       ]
     },
     "validTo": {
       "description": "RFC3339 UTC end of the period when the resoure is valid (see https://ijmacd.github.io/rfc3339-iso8601/ for format guidance).",
-      "type": ["string", "null"],
-      "allOf": [
-        {
-          "$ref": "../types/icarDateTimeType.json"
-        }
+      "anyOf": [
+        {"type": "null"},
+        {"$ref": "../types/icarDateTimeType.json"}
       ]
     }
   }


### PR DESCRIPTION
There seems to be an issue with nullable $ref-Types in IcarMetaData leading to

> INFO o.o.codegen.InlineModelResolver - allOf schema used by the property created replaced by its only item (a type)

The fix follows the suggested way discussed here: https://stackoverflow.com/a/48114924

With this fix, the output of the InlineModelResolver disappears.