### PR TITLE
Add doItYourself to insemination

### DIFF
--- a/resources/icarReproInseminationEventResource.json
+++ b/resources/icarReproInseminationEventResource.json
@@ -53,6 +53,10 @@
         "embryo": {
           "$ref": "../resources/icarReproEmbryoResource.json",
           "description": "Details of the embryo."
+        },
+        "doItYourself": {
+          "type": "boolean",
+          "description": "Only where inseminationType is `insemination`: true if farmer applied, false or not specified if by AI company."
         }
       }
     }


### PR DESCRIPTION
Resolves #494 
The `doItYourself` property should be `true` if the `inseminationType` is `"insemination"` and the farmer carried out the insemination, rather than a technician from the AI or breeding company.

This property is not used for `"NaturalService"` or `"RunWithBull"` insemination types.

Because this property is new, if it is not specified you cannot guarantee whether the insemination was farmer or AI company applied. If it is definitely AI company applied and you want this to be known, you should set `doItYourself` to `false`.