### PR TITLE
Standardise icarDurationType enum to use ISO8601 period syntax

### DIFF
--- a/enums/icarDurationType.json
+++ b/enums/icarDurationType.json
@@ -1,15 +1,15 @@
 {
-  "description": "ISO8601/RFC3339 durations used in various types of aggregations. D=Day, M=Month, W=Week, Y=Year, H=Hour, M=Min.",
+  "description": "ISO8601 durations used in aggregations:\n (1 day - typically from midnight, 1 hour, 24 hour period, 96 hour period, 1 week, 1 month)",
 
   "type": "string",
 
   "enum": [
-    "1D",
-    "1H",
-    "24H",
-    "96H",
-    "1W",
-    "1M"
+    "P1D",
+    "PT1H",
+    "PT24H",
+    "PT96H",
+    "P1W",
+    "P1M"
   ]
 }
 


### PR DESCRIPTION
Change icarDurationType (used by the icarObservationSummaryResource statistics) to use ISO8601 periods.
These periods
- Begin with the literal "P"
- Optionally have a number of days, weeks, or months using "D", "W", or "M"
- Optionally have a "T" separator for time
- Optionally have a number of hours and minutes using "H", "M".

Resolves #517