### PR TITLE
Add POST methods for icarObservationSummaryResource

### DIFF
--- a/url-schemes/managementURLScheme.json
+++ b/url-schemes/managementURLScheme.json
@@ -956,7 +956,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/icarDeviceResource"
+                                    "$ref": "#/components/schemas/icarRemarkEventResource"
                                 }
                             }
                         }
@@ -1042,6 +1042,72 @@
                                 "schema": {
                                     "$ref": "#/components/schemas/icarObservationSummaryCollection"
                                 }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/default"
+                    }
+                }
+            },
+            "post": {
+                "operationId": "post-single-observation-summary-metrics",
+                "summary": "Add a single new observation summary resource.",
+                "description": "# Purpose\nAllows a client to add a single observation summary resource.\n",
+                "tags": [
+                    "ADE-1.4-management"
+                ],
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/location-scheme"
+                    },
+                    {
+                        "$ref": "#/components/parameters/location-id"
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "description": "The resource to create. \nA client MAY fill in the *Id* field with a client-generated UUID and the server MAY use this *Id*.\nIf the server does not use the client-specified *ID* field it shall issue its own *ID* for the resource.\nA client SHALL ensure that the *meta.source* and *meta.sourceId* fields are filled by the client.\n",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/icarObservationSummaryResource"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful. The response contains a copy of the resource, as modifed by the server.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/icarObservationSummaryResource"
+                                }
+                            }
+                        }
+                    },
+                    "201": {
+                        "description": "Created. The Location header contains the URI to the new resource.",
+                        "headers": {
+                            "Location": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "uri"
+                                },
+                                "description": "Contains the URI to the new resource."
+                            }
+                        }
+                    },
+                    "202": {
+                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
+                        "headers": {
+                            "Location": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "uri"
+                                },
+                                "description": "Contains a URI to query creation status."
                             }
                         }
                     },
@@ -1800,6 +1866,81 @@
                     }
                 }
             }
+        },
+        "/batches/locations/{location-scheme}/{location-id}/observation-summary-metrics": {
+            "post": {
+                "operationId": "post-batch-observation-summary-metrics",
+                "summary": "Add an array of observation summary resources.",
+                "description": "# Purpose \nAllows a client to add a collection of observation summary resources.\n",
+                "tags": [
+                    "ADE-1.4-management"
+                ],
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/location-scheme"
+                    },
+                    {
+                        "$ref": "#/components/parameters/location-id"
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "description": "The collection of observation summary resources to create. \nA client MAY fill in resource *Id*s with a client-generated UUID and the server MAY use these *Id*s.\nIf the server does not use the client-specified *Id* field it shall issue its own *Id*s for the resources.\nA client SHALL ensure that the *meta.source* and *meta.sourceId* fields are filled by the client.\n",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/icarObservationSummaryResourceArray"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/batchResults"
+                                }
+                            }
+                        }
+                    },
+                    "201": {
+                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
+                        "headers": {
+                            "Location": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "uri"
+                                },
+                                "description": "Contains the URI to the results."
+                            }
+                        }
+                    },
+                    "202": {
+                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
+                        "headers": {
+                            "Location": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "uri"
+                                },
+                                "description": "Contains a URI to query creation status."
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "The response contains a set of batch results, which may include errors and warnings.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/batchResults"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "components": {
@@ -1933,8 +2074,17 @@
                     "$ref": "#/components/schemas/icarRemarkEventResource"
                 }
             },
+            "icarObservationSummaryResource": {
+                "$ref": "../resources/icarObservationSummaryResource.json"
+            },
             "icarObservationSummaryCollection": {
                 "$ref": "../collections/icarObservationSummaryCollection.json"
+            },
+            "icarObservationSummaryResourceArray": {
+                "type": "array",
+                "items": {
+                    "$ref": "#/components/schemas/icarObservationSummaryResource"
+                }
             }
         },
         "parameters": {


### PR DESCRIPTION
Add single and batch POST methods for icarObservationSummaryResource.
Resolves #510 

Also corrects one problem with the definition of single POST for icarRemarkResource.