### PR TITLE
Update icarAnimalGenderType.json

### DIFF
--- a/enums/icarAnimalGenderType.json
+++ b/enums/icarAnimalGenderType.json
@@ -6,6 +6,7 @@
   "enum": [
     "Female",
     "FemaleNeuter",
+    "Freemartin",
     "Male",
     "MaleCryptorchid",
     "MaleNeuter",


### PR DESCRIPTION
Add Freemartin to AnimalGenderType. Incomplete female usually due to being born as a twin. Not specifically a gender but used in the UK and internationally to indicate an infertile female calf.