### PR TITLE
Add Euthanized to icarDeathMethodType

### DIFF
--- a/enums/icarDeathMethodType.json
+++ b/enums/icarDeathMethodType.json
@@ -1,5 +1,5 @@
 { 
-    "description": "Enumeration for method of death (whether the animal died from an accident, natural causes, or was euthanised).",
+    "description": "Enumeration for method of death.\n Note: Some organisations will use Euthanized and Culled as synonyms. Culling may be euthanasia for disease control purposes.\n Culling is also used to describe live animal departures (out of this scope).",
     
     "type": "string",
   
@@ -10,6 +10,7 @@
       "Theft",
       "Lost",
       "Accident",
+      "Euthanized",
       "Other"
     ]
   }


### PR DESCRIPTION
Add "Euthanized" enum to icarDeathMethodType.
Resolves #515 

As an aside, we had a conversation about "Culled" vs. "Slaughtered" vs. "Euthanized".
Different systems will use this in different ways. "Culled" is often used as a reason for departures (unwanted animals are sold - culled). However in the context of deaths:
* Slaughter - typically means the animal has been killed for food (for people or other animals)
* Culled - may be used when animals are killed to stop disease spreading, or for biosecurity requirements
* Euthanized - describes an animal killed humanely because otherwise it would suffer (e.g from disease or injury)

We also talked about the challenges of documentation for enums, and I noted this conversation in the JSON Schema specification development: https://github.com/json-schema-org/json-schema-spec/issues/57#issuecomment-247855548 (just interesting).