### PR TITLE
539_group_feedings_required

### DIFF
--- a/resources/icarGroupFeedingEventResource.json
+++ b/resources/icarGroupFeedingEventResource.json
@@ -1,6 +1,7 @@
 {
     "description": "Event for recording group or mob feeding. Allowances represent averages so this cannot be used to populate individual animal events.",
     "type": "object",
+    "required": ["eventDateTime", "location", "groupMethod"],
     "allOf": [
         {
             "$ref": "../resources/icarGroupEventCoreResource.json"

--- a/resources/icarGroupFeedingEventResource.json
+++ b/resources/icarGroupFeedingEventResource.json
@@ -1,7 +1,7 @@
 {
     "description": "Event for recording group or mob feeding. Allowances represent averages so this cannot be used to populate individual animal events.",
     "type": "object",
-    "required": ["eventDateTime", "location", "groupMethod"],
+    "required": ["eventDateTime", "location"],
     "allOf": [
         {
             "$ref": "../resources/icarGroupEventCoreResource.json"


### PR DESCRIPTION
Add required fields to `icarGroupFeedingEventResource`.
Needs `eventDateTime`, `location`, `groupMethod` to make sense and align with other group events.

Resolves #539