### PR TITLE
534_device_animal_simplistic

### DIFF
--- a/resources/icarDeviceResource.json
+++ b/resources/icarDeviceResource.json
@@ -59,7 +59,11 @@
       "registration": {
         "$ref": "../types/icarDeviceRegistrationIdentifierType.json",
         "description": "A registration identifier for the device (most devices should eventually have a registration issued by `org.icar` or other entity)."
-      }
+      },
+        "animal": {
+          "$ref": "../types/icarAnimalIdentifierType.json",
+          "description": "If specified, contains the identifier of an animal that the device is currently associated with."
+        }      
     }
   }]
 }


### PR DESCRIPTION
Simplest solution to #534.
Adds optional `animal` (`icarAimalIdentifierType`) to `icarDeviceResource` to provide the currently associated animal (if any). 

Comments welcome:
* Is the name sufficient, or would `associatedAnimal` be better? Most other animal identifiers are just called `animal` where used.
* We discussed an array of identifiers with validity periods to provide a historic view, but most people felt this would be confusing and unnecessary.
* We discussed join/leave or `association` events, but I have left this out of initial scope.

Resolves #534