### PR TITLE
Fix combine schema metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Usage:
 * Navigate to the directory containing the script
 * Run the script: ".\schema_bundle.ps1" or "./schema_bundle.sh"
 * The script will clean up the existing files in the **bundled-schemes** folder, then bundle the schemas listed in the script and save them in the same bundled-schemes folder.
+* Once the schemes bundle operation is completed, the script will combine all bundled schemes, except for ExampleScheme, into a single file named **combinedURLScheme.json**, which will be placed in the **bundled-schemes** folder.
 Bundle JSON Schemas workflow:
 * When changes are merged into the **ADE-1** branch, the workflow will automatically trigger and bundle the schemas into the **bundled-schemes** folder.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ Usage:
 * Navigate to the directory containing the script
 * Run the script: ".\schema_bundle.ps1" or "./schema_bundle.sh"
 * The script will clean up the existing files in the **bundled-schemes** folder, then bundle the schemas listed in the script and save them in the same bundled-schemes folder.
-* Once the schemes bundle operation is completed, the script will combine all bundled schemes, except for ExampleScheme, into a single file named **combinedURLScheme.json**, which will be placed in the **bundled-schemes** folder. The openapi-merge-cli tool, which is used to combine schemas, currently supports OpenAPI 3.0 but merges 3.1 schemas correctly. However, it defaults to version 3.0.3 in the final output. By manually editing the **combinedURLScheme.json** file, the OpenAPI version can be changed from 3.0.3 to 3.1.0.
 Bundle JSON Schemas workflow:
 * When changes are merged into the **ADE-1** branch, the workflow will automatically trigger and bundle the schemas into the **bundled-schemes** folder.
 

--- a/scripts/combine-metadata.json
+++ b/scripts/combine-metadata.json
@@ -1,0 +1,15 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Full ICAR API Specifications",
+    "description": "Specifications for all message types.",
+    "version": "1.4",
+    "contact": {
+      "name": "Animal Data Exchange Working Group",
+      "url": "https://www.icar.org/index.php/technical-bodies/working-groups/animal-data-exchange-wg/",
+      "email": "icar@icar.org"
+    }
+  },
+  "paths": {},
+  "components": {}
+}

--- a/scripts/combine-schemes.json
+++ b/scripts/combine-schemes.json
@@ -1,6 +1,9 @@
 {
   "inputs": [
     {
+      "inputFile": "./combine-metadata.json"
+    },
+    {
       "inputFile": "../bundled-schemes/feedURLscheme.json"
     },
     {

--- a/scripts/schema_bundle.ps1
+++ b/scripts/schema_bundle.ps1
@@ -5,8 +5,8 @@ if (-not (Get-Command "npm" -ErrorAction SilentlyContinue)) {
 }
 
 # List of available schemas
-$Schemas = @("exampleUrlScheme.json", 
-            "feedURLscheme.json", 
+$Schemas = @("exampleUrlScheme.json",
+            "feedURLscheme.json",
             "healthURLScheme.json",
             "managementURLScheme.json",
             "milkURLScheme.json",
@@ -22,7 +22,7 @@ $CombineSchemeConfigPath = "../scripts/combine-schemes.json"
 # Remove old bundled schemas
 if (Test-Path -Path $BundledSchemasPath) {
     Write-Output "Cleaning up old bundled schemas in $BundledSchemasPath..."
-    Remove-Item -Path "$BundledSchemasPath\*" -Recurse -Force 
+    Remove-Item -Path "$BundledSchemasPath\*" -Recurse -Force
     Write-Output "Old bundled schemas cleaned up."
 } else {
     Write-Output "$BundledSchemasPath not found. Skipping cleanup."
@@ -53,11 +53,14 @@ foreach ($Schema in $Schemas) {
 Write-Output "Bundle completed."
 
 # Combine bundled schemes into the single file
-if (Test-Path $UrlSchemesPath -PathType Container) {    
+if (Test-Path $UrlSchemesPath -PathType Container) {
     if ((Get-ChildItem $UrlSchemesPath | Measure-Object).Count -gt 0) {
 		try {
-				& npx --yes openapi-merge-cli --config $CombineSchemeConfigPath			
+				& npx --yes openapi-merge-cli --config $CombineSchemeConfigPath
 				Write-Output "Schemes combined successfully."
+				# replace 3.0.3 with 3.1.0 in bundled-schemes/combinedURLScheme.json file
+				(Get-Content "$BundledSchemasPath/combinedURLScheme.json") -replace '"openapi": "3.0.3"', '"openapi": "3.1.0"' | Set-Content "$BundledSchemasPath/combinedURLScheme.json"
+				Write-Output "Specification patched properly to openapi 3.1.0."
 		} catch {
 			Write-Error "Failed to combine schemes. Error: $_"
 		}

--- a/scripts/schema_bundle.sh
+++ b/scripts/schema_bundle.sh
@@ -62,6 +62,9 @@ if [ -d "$UrlSchemesPath" ]; then
     if [ "$(ls -A "$UrlSchemesPath")" ]; then
         if npx --yes openapi-merge-cli --config "$CombineSchemeConfigPath"; then
             echo "Schemes combined successfully."
+            # replace 3.0.3 with 3.1.0 in bundled-schemes/combinedURLScheme.json file
+            sed -i '' 's/"openapi": "3.0.3"/"openapi": "3.1.0"/' "$BundledSchemasPath/combinedURLScheme.json"
+            echo "Specification patched properly to openapi 3.1.0."
         else
             echo "Failed to combine schemes."
             exit 1


### PR DESCRIPTION
- [x] Fixes #548 This is a patch until robertmassaioli/openapi-merge#76 is fixed
- [x] The metadata being used was the one of `url-schemes/feedURLscheme.json`

Before the fix:
```json
{
  "openapi": "3.0.3",
  "info": {
    "title": "Feed-related events and messages API Specifications",
    "description": "Specifications for messages that support livestock feeding and feed management.",
    "version": "1.4",
    "contact": {
      "name": "Animal Data Exchange Working Group",
      "url": "https://www.icar.org/index.php/technical-bodies/working-groups/animal-data-exchange-wg/",
      "email": "icar@icar.org"
    }
  },
```

After the fix:
```json
{
  "openapi": "3.1.0",
  "info": {
    "title": "Full ICAR API Specifications",
    "description": "Specifications for all message types.",
    "version": "1.4",
    "contact": {
      "name": "Animal Data Exchange Working Group",
      "url": "https://www.icar.org/index.php/technical-bodies/working-groups/animal-data-exchange-wg/",
      "email": "icar@icar.org"
    }
  },
```

The metadata I put needs to be validated, it can be updated in the new `scripts/combine-metadata.json` file I added in this PR.