### PR TITLE
Change script execution to use bash explicitly

### DIFF
--- a/.github/workflows/schema_bundle.yml
+++ b/.github/workflows/schema_bundle.yml
@@ -24,7 +24,7 @@ jobs:
     # Run the Shell script to bundle schemas
     - name: Run schema bundling script
       run: |
-        ./scripts/schema_bundle.sh
+        bash ./scripts/schema_bundle.sh
     
     - name: Output results
       run: |


### PR DESCRIPTION
Recommended by CoPilot as a solution to the script failing to detect Node/NPM.