### PR TITLE
Wrap $ref with allOf for JSON snippets

### DIFF
--- a/url-schemes/healthURLScheme.json
+++ b/url-schemes/healthURLScheme.json
@@ -1240,7 +1240,7 @@
       "batchResults": {
         "type": "array",
         "items": {
-            "$ref": "../resources/icarBatchResult.json" 
+          "$ref": "../resources/icarBatchResult.json"
         }
       },
       "icarDiagnosisEvent": {

--- a/url-schemes/healthURLScheme.json
+++ b/url-schemes/healthURLScheme.json
@@ -1240,9 +1240,7 @@
       "batchResults": {
         "type": "array",
         "items": {
-          "allOf": [
-            { "$ref": "../resources/icarBatchResult.json" }
-          ]
+            "$ref": "../resources/icarBatchResult.json" 
         }
       },
       "icarDiagnosisEvent": {
@@ -1258,9 +1256,7 @@
       "icarDiagnosisEventArray": {
         "type": "array",
         "items": {
-          "allOf": [
-            { "$ref": "../resources/icarDiagnosisEventResource.json" }
-          ]
+             "$ref": "../resources/icarDiagnosisEventResource.json" 
         }
       },
       "icarTreatmentEvent": {
@@ -1276,9 +1272,7 @@
       "icarTreatmentEventArray": {
         "type": "array",
         "items": {
-          "allOf": [
-            { "$ref": "../resources/icarTreatmentEventResource.json" }
-          ]
+           "$ref": "../resources/icarTreatmentEventResource.json" 
         }
       },
       "icarGroupTreatmentEvent": {
@@ -1294,9 +1288,7 @@
       "icarGroupTreatmentEventArray": {
         "type": "array",
         "items": {
-          "allOf": [
-            { "$ref": "../resources/icarGroupTreatmentEventResource.json" }
-          ]
+             "$ref": "../resources/icarGroupTreatmentEventResource.json" 
         }
       },
       "icarTreatmentProgramEvent": {
@@ -1312,9 +1304,7 @@
       "icarTreatmentProgramEventArray": {
         "type": "array",
         "items": {
-          "allOf": [
-            { "$ref": "../resources/icarTreatmentProgramEventResource.json" }
-          ]
+            "$ref": "../resources/icarTreatmentProgramEventResource.json" 
         }
       },
       "icarHealthStatusObservedEvent": {
@@ -1330,9 +1320,7 @@
       "icarHealthStatusObservedArray": {
         "type": "array",
         "items": {
-          "allOf": [
-            { "$ref": "../resources/icarHealthStatusObservedEventResource.json" }
-          ]
+             "$ref": "../resources/icarHealthStatusObservedEventResource.json" 
         }
       },
       "icarMedicineTransactionResource": {

--- a/url-schemes/healthURLScheme.json
+++ b/url-schemes/healthURLScheme.json
@@ -1240,74 +1240,110 @@
       "batchResults": {
         "type": "array",
         "items": {
-          "$ref": "../resources/icarBatchResult.json"
+          "allOf": [
+            { "$ref": "../resources/icarBatchResult.json" }
+          ]
         }
       },
       "icarDiagnosisEvent": {
-        "$ref": "../resources/icarDiagnosisEventResource.json"
+        "allOf": [
+          { "$ref": "../resources/icarDiagnosisEventResource.json" }
+        ]
       },
       "icarDiagnosisEventCollection": {
-        "$ref": "../collections/icarDiagnosisEventCollection.json"
+        "allOf": [
+          { "$ref": "../collections/icarDiagnosisEventCollection.json" }
+        ]
       },
       "icarDiagnosisEventArray": {
         "type": "array",
         "items": {
-          "$ref": "../resources/icarDiagnosisEventResource.json" 
+          "allOf": [
+            { "$ref": "../resources/icarDiagnosisEventResource.json" }
+          ]
         }
       },
       "icarTreatmentEvent": {
-        "$ref": "../resources/icarTreatmentEventResource.json"
+        "allOf": [
+          { "$ref": "../resources/icarTreatmentEventResource.json" }
+        ]
       },
       "icarTreatmentEventCollection": {
-        "$ref": "../collections/icarTreatmentEventCollection.json"
+        "allOf": [
+          { "$ref": "../collections/icarTreatmentEventCollection.json" }
+        ]
       },
       "icarTreatmentEventArray": {
         "type": "array",
         "items": {
-          "$ref": "../resources/icarTreatmentEventResource.json"
+          "allOf": [
+            { "$ref": "../resources/icarTreatmentEventResource.json" }
+          ]
         }
       },
       "icarGroupTreatmentEvent": {
-        "$ref": "../resources/icarGroupTreatmentEventResource.json"
+        "allOf": [
+          { "$ref": "../resources/icarGroupTreatmentEventResource.json" }
+        ]
       },
       "icarGroupTreatmentEventCollection": {
-        "$ref": "../collections/icarGroupTreatmentEventCollection.json"
+        "allOf": [
+          { "$ref": "../collections/icarGroupTreatmentEventCollection.json" }
+        ]
       },
       "icarGroupTreatmentEventArray": {
         "type": "array",
         "items": {
-          "$ref": "../resources/icarGroupTreatmentEventResource.json"
+          "allOf": [
+            { "$ref": "../resources/icarGroupTreatmentEventResource.json" }
+          ]
         }
       },
       "icarTreatmentProgramEvent": {
-        "$ref": "../resources/icarTreatmentProgramEventResource.json"
+        "allOf": [
+          { "$ref": "../resources/icarTreatmentProgramEventResource.json" }
+        ]
       },
       "icarTreatmentProgramEventCollection": {
-        "$ref": "../collections/icarTreatmentProgramEventCollection.json"
+        "allOf": [
+          { "$ref": "../collections/icarTreatmentProgramEventCollection.json" }
+        ]
       },
       "icarTreatmentProgramEventArray": {
         "type": "array",
         "items": {
-          "$ref": "../resources/icarTreatmentProgramEventResource.json"
+          "allOf": [
+            { "$ref": "../resources/icarTreatmentProgramEventResource.json" }
+          ]
         }
       },
       "icarHealthStatusObservedEvent": {
-        "$ref": "../resources/icarHealthStatusObservedEventResource.json"
+        "allOf": [
+          { "$ref": "../resources/icarHealthStatusObservedEventResource.json" }
+        ]
       },
       "icarHealthStatusObservedEventCollection": {
-        "$ref": "../collections/icarHealthStatusObservedEventCollection.json"
+        "allOf": [
+          { "$ref": "../collections/icarHealthStatusObservedEventCollection.json" }
+        ]
       },
       "icarHealthStatusObservedArray": {
         "type": "array",
         "items": {
-          "$ref": "../resources/icarHealthStatusObservedEventResource.json"
+          "allOf": [
+            { "$ref": "../resources/icarHealthStatusObservedEventResource.json" }
+          ]
         }
       },
       "icarMedicineTransactionResource": {
-        "$ref": "../resources/icarMedicineTransactionResource.json"
+        "allOf": [
+          { "$ref": "../resources/icarMedicineTransactionResource.json" }
+        ]
       },
       "icarMedicineTransactionCollection": {
-        "$ref": "../collections/icarMedicineTransactionCollection.json"
+        "allOf": [
+          { "$ref": "../collections/icarMedicineTransactionCollection.json" }
+        ]
       },
       "icarMedicineTransactionArray": {
         "type": "array",
@@ -1316,10 +1352,14 @@
         }
       },
       "icarAttentionEventResource": {
-        "$ref": "../resources/icarAttentionEventResource.json"
+        "allOf": [
+          { "$ref": "../resources/icarAttentionEventResource.json" }
+        ]
       },
       "icarAttentionEventCollection": {
-        "$ref": "../collections/icarAttentionEventCollection.json"
+        "allOf": [
+          { "$ref": "../collections/icarAttentionEventCollection.json" }
+        ]
       },
       "icarAttentionEventArray": {
         "type": "array",

--- a/url-schemes/managementURLScheme.json
+++ b/url-schemes/managementURLScheme.json
@@ -1897,9 +1897,7 @@
             "batchResults": {
                 "type": "array",
                 "items": {
-                    "allOf": [
-                        { "$ref": "../resources/icarBatchResult.json" }
-                    ]
+                    "$ref": "../resources/icarBatchResult.json"
                 }
             },
             "icarAnimalSetResource": {

--- a/url-schemes/managementURLScheme.json
+++ b/url-schemes/managementURLScheme.json
@@ -1897,14 +1897,20 @@
             "batchResults": {
                 "type": "array",
                 "items": {
-                    "$ref": "../resources/icarBatchResult.json"
+                    "allOf": [
+                        { "$ref": "../resources/icarBatchResult.json" }
+                    ]
                 }
             },
             "icarAnimalSetResource": {
-                "$ref": "../resources/icarAnimalSetResource.json"
+                "allOf": [
+                  { "$ref": "../resources/icarAnimalSetResource.json" }
+                ]
             },
             "icarAnimalSetCollection": {
-                "$ref": "../collections/icarAnimalSetCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarAnimalSetCollection.json" }
+                ]
             },
             "icarAnimalSetArray": {
                 "type": "array",
@@ -1913,10 +1919,14 @@
                 }
             },
             "icarAnimalSetJoinEventResource": {
-                "$ref": "../resources/icarAnimalSetJoinEventResource.json"
+                "allOf": [
+                  { "$ref": "../resources/icarAnimalSetJoinEventResource.json" }
+                ]
             },
             "icarAnimalSetJoinEventCollection": {
-                "$ref": "../collections/icarAnimalSetJoinEventCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarAnimalSetJoinEventCollection.json" }
+                ]
             },
             "icarAnimalSetJoinEventArray": {
                 "type": "array",
@@ -1925,10 +1935,14 @@
                 }
             },
             "icarAnimalSetLeaveEventResource": {
-                "$ref": "../resources/icarAnimalSetLeaveEventResource.json"
+                "allOf": [
+                  { "$ref": "../resources/icarAnimalSetLeaveEventResource.json" }
+                ]
             },
             "icarAnimalSetLeaveEventCollection": {
-                "$ref": "../collections/icarAnimalSetLeaveEventCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarAnimalSetLeaveEventCollection.json" }
+                ]
             },
             "icarAnimalSetLeaveEventArray": {
                 "type": "array",
@@ -1937,13 +1951,19 @@
                 }
             },
             "icarDeviceResource": {
-                "$ref": "../resources/icarDeviceResource.json"
+                "allOf": [
+                  { "$ref": "../resources/icarDeviceResource.json" }
+                ]
             },
             "icarDeviceCollection": {
-                "$ref": "../collections/icarDeviceCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarDeviceCollection.json" }
+                ]
             },
             "icarStatisticsCollection": {
-                "$ref": "../collections/icarStatisticsCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarStatisticsCollection.json" }
+                ]
             },
             "icarDeviceArray": {
                 "type": "array",
@@ -1952,10 +1972,14 @@
                 }
             },
             "icarInventoryTransactionResource": {
-                "$ref": "../resources/icarInventoryTransactionResource.json"
+                "allOf": [
+                  { "$ref": "../resources/icarInventoryTransactionResource.json" }
+                ]
             },
             "icarInventoryTransactionCollection": {
-                "$ref": "../collections/icarInventoryTransactionCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarInventoryTransactionCollection.json" }
+                ]
             },
             "icarInventoryTransactionArray": {
                 "type": "array",
@@ -1964,10 +1988,14 @@
                 }
             },
             "icarFeedTransactionResource": {
-                "$ref": "../resources/icarFeedTransactionResource.json"
+                "allOf": [
+                  { "$ref": "../resources/icarFeedTransactionResource.json" }
+                ]
             },
             "icarFeedTransactionCollection": {
-                "$ref": "../collections/icarFeedTransactionCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarFeedTransactionCollection.json" }
+                ]
             },
             "icarFeedTransactionArray": {
                 "type": "array",
@@ -1976,10 +2004,14 @@
                 }
             },
             "icarMedicineTransactionResource": {
-                "$ref": "../resources/icarMedicineTransactionResource.json"
+                "allOf": [
+                  { "$ref": "../resources/icarMedicineTransactionResource.json" }
+                ]
             },
             "icarMedicineTransactionCollection": {
-                "$ref": "../collections/icarMedicineTransactionCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarMedicineTransactionCollection.json" }
+                ]
             },
             "icarMedicineTransactionArray": {
                 "type": "array",
@@ -1988,10 +2020,14 @@
                 }
             },
             "icarGroupPositionObservationEventResource": {
-                "$ref": "../resources/icarGroupPositionObservationEventResource.json"
+                "allOf": [
+                  { "$ref": "../resources/icarGroupPositionObservationEventResource.json" }
+                ]
             },
             "icarGroupPositionObservationEventCollection": {
-                "$ref": "../collections/icarGroupPositionObservationEventCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarGroupPositionObservationEventCollection.json" }
+                ]
             },
             "icarGroupPositionObservationEventArray": {
                 "type": "array",
@@ -2000,10 +2036,14 @@
                 }
             },
             "icarPositionObservationEventResource": {
-                "$ref": "../resources/icarPositionObservationEventResource.json"
+                "allOf": [
+                  { "$ref": "../resources/icarPositionObservationEventResource.json" }
+                ]
             },
             "icarPositionObservationEventCollection": {
-                "$ref": "../collections/icarPositionObservationEventCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarPositionObservationEventCollection.json" }
+                ]
             },
             "icarPositionObservationEventArray": {
                 "type": "array",
@@ -2012,10 +2052,14 @@
                 }
             },
             "icarRemarkEventResource": {
-                "$ref": "../resources/icarRemarkEventResource.json"
+                "allOf": [
+                  { "$ref": "../resources/icarRemarkEventResource.json" }
+                ]
             },
             "icarRemarkEventCollection": {
-                "$ref": "../collections/icarRemarkEventCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarRemarkEventCollection.json" }
+                ]
             },
             "icarRemarkEventArray": {
                 "type": "array",
@@ -2024,10 +2068,14 @@
                 }
             },
             "icarObservationSummaryResource": {
-                "$ref": "../resources/icarObservationSummaryResource.json"
+                "allOf": [
+                  { "$ref": "../resources/icarObservationSummaryResource.json" }
+                ]
             },
             "icarObservationSummaryCollection": {
-                "$ref": "../collections/icarObservationSummaryCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarObservationSummaryCollection.json" }
+                ]
             },
             "icarObservationSummaryResourceArray": {
                 "type": "array",

--- a/url-schemes/milkURLScheme.json
+++ b/url-schemes/milkURLScheme.json
@@ -946,14 +946,20 @@
             "batchResults": {
                 "type": "array",
                 "items": {
-                    "$ref": "../resources/icarBatchResult.json"
+                  "allOf": [
+                    { "$ref": "../resources/icarBatchResult.json" }
+                  ]
                 }
             },
             "icarMilkingVisitEventResource": {
-                "$ref": "../resources/icarMilkingVisitEventResource.json"
+                "allOf": [
+                  { "$ref": "../resources/icarMilkingVisitEventResource.json" }
+                ]
             },
             "icarMilkingVisitEventCollection": {
-                "$ref": "../collections/icarMilkingVisitEventCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarMilkingVisitEventCollection.json" }
+                ]
             },
             "icarMilkingVisitEventArray": {
                 "type": "array",
@@ -962,10 +968,14 @@
                 }
             },
             "icarTestDayResource": {
-                "$ref": "../resources/icarTestDayResource.json"
+                "allOf": [
+                  { "$ref": "../resources/icarTestDayResource.json" }
+                ]
             },
             "icarTestDayCollection": {
-                "$ref": "../collections/icarTestDayCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarTestDayCollection.json" }
+                ]
             },
             "icarTestDayArray": {
                 "type": "array",
@@ -974,10 +984,14 @@
                 }
             },
             "icarTestDayResultEventResource": {
-                "$ref": "../resources/icarTestDayResultEventResource.json"
+                "allOf": [
+                  { "$ref": "../resources/icarTestDayResultEventResource.json" }
+                ]
             },
             "icarTestDayResultEventCollection": {
-                "$ref": "../collections/icarTestDayResultEventCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarTestDayResultEventCollection.json" }
+                ]
             },
             "icarTestDayResultEventArray": {
                 "type": "array",
@@ -986,19 +1000,29 @@
                 }
             },
             "icarDailyMilkingAveragesCollection": {
-                "$ref": "../collections/icarDailyMilkingAveragesCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarDailyMilkingAveragesCollection.json" }
+                ]
             },
              "icarMilkPredictionsCollection": {
-                "$ref": "../collections/icarMilkPredictionsCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarMilkPredictionsCollection.json" }
+                ]
             },
             "icarLactationCollection": {
-                "$ref": "../collections/icarLactationCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarLactationCollection.json" }
+                ]
             },
             "icarLactationStatusObservedEventResource": {
-                "$ref": "../resources/icarLactationStatusObservedEventResource.json"
+                "allOf": [
+                  { "$ref": "../resources/icarLactationStatusObservedEventResource.json" }
+                ]
             },
             "icarLactationStatusObservedEventCollection": {
-                "$ref": "../collections/icarLactationStatusObservedEventCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarLactationStatusObservedEventCollection.json" }
+                ]
             },
             "icarLactationStatusObservedEventArray": {
                 "type": "array",
@@ -1007,7 +1031,9 @@
                 }
             },
             "icarWithdrawalEventCollection": {
-                "$ref": "../collections/icarWithdrawalEventCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarWithdrawalEventCollection.json" }
+                ]
             }
         },
         "parameters": {

--- a/url-schemes/milkURLScheme.json
+++ b/url-schemes/milkURLScheme.json
@@ -946,9 +946,7 @@
             "batchResults": {
                 "type": "array",
                 "items": {
-                  "allOf": [
-                    { "$ref": "../resources/icarBatchResult.json" }
-                  ]
+                    "$ref": "../resources/icarBatchResult.json"
                 }
             },
             "icarMilkingVisitEventResource": {

--- a/url-schemes/performanceURLScheme.json
+++ b/url-schemes/performanceURLScheme.json
@@ -736,14 +736,20 @@
             "batchResults": {
                 "type": "array",
                 "items": {
-                    "$ref": "../resources/icarBatchResult.json"
+                  "allOf": [
+                    { "$ref": "../resources/icarBatchResult.json" }
+                  ]
                 }
             },
             "icarWeightEventResource": {
-                "$ref": "../resources/icarWeightEventResource.json"
+                "allOf": [
+                  { "$ref": "../resources/icarWeightEventResource.json" }
+                ]
             },
             "icarWeightEventCollection": {
-                "$ref": "../collections/icarWeightEventCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarWeightEventCollection.json" }
+                ]
             },
             "icarWeightEventArray": {
                 "type": "array",
@@ -752,10 +758,14 @@
                 }
             },
             "icarGroupWeightEventResource": {
-                "$ref": "../resources/icarGroupWeightEventResource.json"
+                "allOf": [
+                  { "$ref": "../resources/icarGroupWeightEventResource.json" }
+                ]
             },
             "icarGroupWeightEventCollection": {
-                "$ref": "../collections/icarGroupWeightEventCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarGroupWeightEventCollection.json" }
+                ]
             },
             "icarGroupWeightEventArray": {
                 "type": "array",
@@ -764,19 +774,29 @@
                 }
             },
             "icarBreedingValueCollection": {
-                "$ref": "../collections/icarBreedingValueCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarBreedingValueCollection.json" }
+                ]
             },
             "icarTypeClassificationEventResource": {
-                "$ref": "../resources/icarTypeClassificationEventResource.json"
+                "allOf": [
+                  { "$ref": "../resources/icarTypeClassificationEventResource.json" }
+                ]
             },
             "icarTypeClassificationEventCollection": {
-                "$ref": "../collections/icarTypeClassificationEventCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarTypeClassificationEventCollection.json" }
+                ]
             },
             "icarConformationScoreEventResource": {
-                "$ref": "../resources/icarConformationScoreEventResource.json"
+                "allOf": [
+                  { "$ref": "../resources/icarConformationScoreEventResource.json" }
+                ]
             },
             "icarConformationScoreEventCollection": {
-                "$ref": "../collections/icarConformationScoreEventCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarConformationScoreEventCollection.json" }
+                ]
             },
             "icarConformationScoreEventArray": {
                 "type": "array",

--- a/url-schemes/performanceURLScheme.json
+++ b/url-schemes/performanceURLScheme.json
@@ -736,9 +736,7 @@
             "batchResults": {
                 "type": "array",
                 "items": {
-                  "allOf": [
-                    { "$ref": "../resources/icarBatchResult.json" }
-                  ]
+                    "$ref": "../resources/icarBatchResult.json"
                 }
             },
             "icarWeightEventResource": {

--- a/url-schemes/registrationURLScheme.json
+++ b/url-schemes/registrationURLScheme.json
@@ -1696,9 +1696,7 @@
             "batchResults": {
                 "type": "array",
                 "items": {
-                  "allOf": [
-                    { "$ref": "../resources/icarBatchResult.json" }
-                  ]
+                    "$ref": "../resources/icarBatchResult.json"
                 }
             },
             "icarLocationCollection": {

--- a/url-schemes/registrationURLScheme.json
+++ b/url-schemes/registrationURLScheme.json
@@ -1696,65 +1696,105 @@
             "batchResults": {
                 "type": "array",
                 "items": {
-                    "$ref": "../resources/icarBatchResult.json"
+                  "allOf": [
+                    { "$ref": "../resources/icarBatchResult.json" }
+                  ]
                 }
             },
             "icarLocationCollection": {
-                "$ref": "../collections/icarLocationCollection.json"
-            },            
+                "allOf": [
+                  { "$ref": "../collections/icarLocationCollection.json" }
+                ]
+            },
             "icarAnimalCoreCollection": {
-                "$ref": "../collections/icarAnimalCoreCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarAnimalCoreCollection.json" }
+                ]
             },
             "icarMovementBirthEventCollection": {
-                "$ref": "../collections/icarMovementBirthEventCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarMovementBirthEventCollection.json" }
+                ]
             },
             "icarGroupMovementBirthEventCollection": {
-                "$ref": "../collections/icarGroupMovementBirthEventCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarGroupMovementBirthEventCollection.json" }
+                ]
             },
             "icarMovementDeathEventCollection": {
-                "$ref": "../collections/icarMovementDeathEventCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarMovementDeathEventCollection.json" }
+                ]
             },
             "icarGroupMovementDeathEventCollection": {
-                "$ref": "../collections/icarGroupMovementDeathEventCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarGroupMovementDeathEventCollection.json" }
+                ]
             },
             "icarMovementArrivalEventCollection": {
-                "$ref": "../collections/icarMovementArrivalEventCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarMovementArrivalEventCollection.json" }
+                ]
             },
             "icarGroupMovementArrivalEventCollection": {
-                "$ref": "../collections/icarGroupMovementArrivalEventCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarGroupMovementArrivalEventCollection.json" }
+                ]
             },
             "icarMovementDepartureEventCollection": {
-                "$ref": "../collections/icarMovementDepartureEventCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarMovementDepartureEventCollection.json" }
+                ]
             },
             "icarGroupMovementDepartureEventCollection": {
-                "$ref": "../collections/icarGroupMovementDepartureEventCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarGroupMovementDepartureEventCollection.json" }
+                ]
             },
             "icarAnimalCoreResource": {
-                "$ref": "../resources/icarAnimalCoreResource.json"
+                "allOf": [
+                  { "$ref": "../resources/icarAnimalCoreResource.json" }
+                ]
             },
             "icarMovementBirthEventResource": {
-                "$ref": "../resources/icarMovementBirthEventResource.json"
+                "allOf": [
+                  { "$ref": "../resources/icarMovementBirthEventResource.json" }
+                ]
             },
             "icarGroupMovementBirthEventResource": {
-                "$ref": "../resources/icarGroupMovementBirthEventResource.json"
+                "allOf": [
+                  { "$ref": "../resources/icarGroupMovementBirthEventResource.json" }
+                ]
             },
             "icarMovementDeathEventResource": {
-                "$ref": "../resources/icarMovementDeathEventResource.json"
+                "allOf": [
+                  { "$ref": "../resources/icarMovementDeathEventResource.json" }
+                ]
             },
             "icarGroupMovementDeathEventResource": {
-                "$ref": "../resources/icarGroupMovementDeathEventResource.json"
+                "allOf": [
+                  { "$ref": "../resources/icarGroupMovementDeathEventResource.json" }
+                ]
             },
             "icarMovementArrivalEventResource": {
-                "$ref": "../resources/icarMovementArrivalEventResource.json"
+                "allOf": [
+                  { "$ref": "../resources/icarMovementArrivalEventResource.json" }
+                ]
             },
             "icarGroupMovementArrivalEventResource": {
-                "$ref": "../resources/icarGroupMovementArrivalEventResource.json"
+                "allOf": [
+                  { "$ref": "../resources/icarGroupMovementArrivalEventResource.json" }
+                ]
             },
             "icarMovementDepartureEventResource": {
-                "$ref": "../resources/icarMovementDepartureEventResource.json"
+                "allOf": [
+                  { "$ref": "../resources/icarMovementDepartureEventResource.json" }
+                ]
             },
             "icarGroupMovementDepartureEventResource": {
-                "$ref": "../resources/icarGroupMovementDepartureEventResource.json"
+                "allOf": [
+                  { "$ref": "../resources/icarGroupMovementDepartureEventResource.json" }
+                ]
             },
             "icarAnimalCoreResourceArray": {
                 "type": "array",

--- a/url-schemes/reproductionURLScheme.json
+++ b/url-schemes/reproductionURLScheme.json
@@ -2074,9 +2074,7 @@
             "batchResults": {
                 "type": "array",
                 "items": {
-                  "allOf": [
-                    { "$ref": "../resources/icarBatchResult.json" }
-                  ]
+                    "$ref": "../resources/icarBatchResult.json"
                 }
             },
             "icarReproPregnancyCheckEventResource": {

--- a/url-schemes/reproductionURLScheme.json
+++ b/url-schemes/reproductionURLScheme.json
@@ -1711,7 +1711,7 @@
                 ],
                 "requestBody": {
                     "required": true,
-                    "description": "The collection of parturitions to create. \nA client MAY fill in resource *Id*s with a client-generated UUID and the server MAY use these *Id*s.\nIf the server does not use the client-specified *Id* field it shall issue its own *Id*s for the resources.\nA client SHALL ensure that the *meta.source* and *meta.sourceId* fields are filled by the client.\n",
+                    "description": "The collection of parturitions to create. \nA client MAY fill in resource *Id*s with a client-generated UUID and the server MAY use these *Id*.\nIf the server does not use the client-specified *Id* field it shall issue its own *Id*s for the resources.\nA client SHALL ensure that the *meta.source* and *meta.sourceId* fields are filled by the client.\n",
                     "content": {
                         "application/json": {
                             "schema": {
@@ -1786,7 +1786,7 @@
                 ],
                 "requestBody": {
                     "required": true,
-                    "description": "The collection of mating recommendations to create. \nA client MAY fill in resource *Id*s with a client-generated UUID and the server MAY use these *Id*s.\nIf the server does not use the client-specified *Id* field it shall issue its own *Id*s for the resources.\nA client SHALL ensure that the *meta.source* and *meta.sourceId* fields are filled by the client.\n",
+                    "description": "The collection of mating recommendations to create. \nA client MAY fill in resource *Id*s with a client-generated UUID and the server MAY use these *Id*.\nIf the server does not use the client-specified *Id* field it shall issue its own *Id*s for the resources.\nA client SHALL ensure that the *meta.source* and *meta.sourceId* fields are filled by the client.\n",
                     "content": {
                         "application/json": {
                             "schema": {
@@ -1861,7 +1861,7 @@
                 ],
                 "requestBody": {
                     "required": true,
-                    "description": "The collection of gestations to create. \nA client MAY fill in resource *Id*s with a client-generated UUID and the server MAY use these *Id*s.\nIf the server does not use the client-specified *Id* field it shall issue its own *Id*s for the resources.\nA client SHALL ensure that the *meta.source* and *meta.sourceId* fields are filled by the client.\n",
+                    "description": "The collection of gestations to create. \nA client MAY fill in resource *Id*s with a client-generated UUID and the server MAY use these *Id*.\nIf the server does not use the client-specified *Id* field it shall issue its own *Id*s for the resources.\nA client SHALL ensure that the *meta.source* and *meta.sourceId* fields are filled by the client.\n",
                     "content": {
                         "application/json": {
                             "schema": {
@@ -2074,14 +2074,20 @@
             "batchResults": {
                 "type": "array",
                 "items": {
-                    "$ref": "../resources/icarBatchResult.json"
+                  "allOf": [
+                    { "$ref": "../resources/icarBatchResult.json" }
+                  ]
                 }
             },
             "icarReproPregnancyCheckEventResource": {
-                "$ref": "../resources/icarReproPregnancyCheckEventResource.json"
+                "allOf": [
+                  { "$ref": "../resources/icarReproPregnancyCheckEventResource.json" }
+                ]
             },
             "icarReproPregnancyCheckEventCollection": {
-                "$ref": "../collections/icarReproPregnancyCheckEventCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarReproPregnancyCheckEventCollection.json" }
+                ]
             },
             "icarReproPregnancyCheckEventArray": {
                 "type": "array",
@@ -2090,10 +2096,14 @@
                 }
             },
             "icarReproHeatEventResource": {
-                "$ref": "../resources/icarReproHeatEventResource.json"
+                "allOf": [
+                  { "$ref": "../resources/icarReproHeatEventResource.json" }
+                ]
             },
             "icarReproHeatEventCollection": {
-                "$ref": "../collections/icarReproHeatEventCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarReproHeatEventCollection.json" }
+                ]
             },
             "icarReproHeatEventArray": {
                 "type": "array",
@@ -2102,10 +2112,14 @@
                 }
             },
             "icarReproInseminationEventResource": {
-                "$ref": "../resources/icarReproInseminationEventResource.json"
+                "allOf": [
+                  { "$ref": "../resources/icarReproInseminationEventResource.json" }
+                ]
             },
             "icarReproInseminationEventCollection": {
-                "$ref": "../collections/icarReproInseminationEventCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarReproInseminationEventCollection.json" }
+                ]
             },
             "icarReproInseminationEventArray": {
                 "type": "array",
@@ -2114,10 +2128,14 @@
                 }
             },
             "icarMilkingDryOffEventResource": {
-                "$ref": "../resources/icarMilkingDryOffEventResource.json"
+                "allOf": [
+                  { "$ref": "../resources/icarMilkingDryOffEventResource.json" }
+                ]
             },
             "icarMilkingDryOffEventCollection": {
-                "$ref": "../collections/icarMilkingDryOffEventCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarMilkingDryOffEventCollection.json" }
+                ]
             },
             "icarMilkingDryOffEventArray": {
                 "type": "array",
@@ -2126,10 +2144,14 @@
                 }
             },
             "icarReproAbortionEventResource": {
-                "$ref": "../resources/icarReproAbortionEventResource.json"
+                "allOf": [
+                  { "$ref": "../resources/icarReproAbortionEventResource.json" }
+                ]
             },
             "icarReproAbortionEventCollection": {
-                "$ref": "../collections/icarReproAbortionEventCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarReproAbortionEventCollection.json" }
+                ]
             },
             "icarReproAbortionEventArray": {
                 "type": "array",
@@ -2138,10 +2160,14 @@
                 }
             },
             "icarReproDoNotBreedEventResource": {
-                "$ref": "../resources/icarReproDoNotBreedEventResource.json"
+                "allOf": [
+                  { "$ref": "../resources/icarReproDoNotBreedEventResource.json" }
+                ]
             },
             "icarReproDoNotBreedEventCollection": {
-                "$ref": "../collections/icarReproDoNotBreedEventCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarReproDoNotBreedEventCollection.json" }
+                ]
             },
             "icarReproDoNotBreedEventArray": {
                 "type": "array",
@@ -2150,10 +2176,14 @@
                 }
             },
             "icarReproParturitionEventResource": {
-                "$ref": "../resources/icarReproParturitionEventResource.json"
+                "allOf": [
+                  { "$ref": "../resources/icarReproParturitionEventResource.json" }
+                ]
             },
             "icarReproParturitionEventCollection": {
-                "$ref": "../collections/icarReproParturitionEventCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarReproParturitionEventCollection.json" }
+                ]
             },
             "icarReproParturitionEventArray": {
                 "type": "array",
@@ -2162,10 +2192,14 @@
                 }
             },
             "icarReproMatingRecommendationResource": {
-                "$ref": "../resources/icarReproMatingRecommendationResource.json"
+                "allOf": [
+                  { "$ref": "../resources/icarReproMatingRecommendationResource.json" }
+                ]
             },
             "icarReproMatingRecommendationCollection": {
-                "$ref": "../collections/icarReproMatingRecommendationCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarReproMatingRecommendationCollection.json" }
+                ]
             },
             "icarReproMatingRecommendationArray": {
                 "type": "array",
@@ -2174,10 +2208,14 @@
                 }
             },
             "icarGestationResource": {
-                "$ref": "../resources/icarGestationResource.json"
+                "allOf": [
+                  { "$ref": "../resources/icarGestationResource.json" }
+                ]
             },
             "icarGestationCollection": {
-                "$ref": "../collections/icarGestationCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarGestationCollection.json" }
+                ]
             },
             "icarGestationArray": {
                 "type": "array",
@@ -2186,10 +2224,14 @@
                 }
             },
             "icarReproStatusObservedEventResource": {
-                "$ref": "../resources/icarReproStatusObservedEventResource.json"
+                "allOf": [
+                  { "$ref": "../resources/icarReproStatusObservedEventResource.json" }
+                ]
             },
             "icarReproStatusObservedEventCollection": {
-                "$ref": "../collections/icarReproStatusObservedEventCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarReproStatusObservedEventCollection.json" }
+                ]
             },
             "icarReproStatusObservedEventArray": {
                 "type": "array",
@@ -2198,10 +2240,14 @@
                 }
             },
             "icarReproEmbryoFlushingEventResource": {
-                "$ref": "../resources/icarReproEmbryoFlushingEventResource.json"
+                "allOf": [
+                  { "$ref": "../resources/icarReproEmbryoFlushingEventResource.json" }
+                ]
             },
             "icarReproEmbryoFlushingEventCollection": {
-                "$ref": "../collections/icarReproEmbryoFlushingEventCollection.json"
+                "allOf": [
+                  { "$ref": "../collections/icarReproEmbryoFlushingEventCollection.json" }
+                ]
             },
             "icarReproEmbryoFlushingEventArray": {
                 "type": "array",

--- a/url-schemes/sortingURLScheme.json
+++ b/url-schemes/sortingURLScheme.json
@@ -230,13 +230,19 @@
   "components": {
     "schemas": {
       "icarAnimalSortingCommandCollection": {
-        "$ref": "../collections/icarAnimalSortingCommandCollection.json"
+        "allOf": [
+          { "$ref": "../collections/icarAnimalSortingCommandCollection.json" }
+        ]
       },
       "icarSortingSiteCollection": {
-        "$ref": "../collections/icarSortingSiteCollection.json"
+        "allOf": [
+          { "$ref": "../collections/icarSortingSiteCollection.json" }
+        ]
       },
       "icarAnimalSortingCommandResource": {
-        "$ref": "../resources/icarAnimalSortingCommandResource.json"
+        "allOf": [
+          { "$ref": "../resources/icarAnimalSortingCommandResource.json" }
+        ]
       }
     },
     "parameters": {


### PR DESCRIPTION
With OpenAPI 3.1, in theory external JSON files that don't contain a schema declaration need to be wrapped in "allOf". Some linters are now enforcing this. Added "allOf" around external $refs.