### PR TITLE
Sire primary breed in insemination - with icarReproSireInfoType

### DIFF
--- a/resources/icarReproEmbryoResource.json
+++ b/resources/icarReproEmbryoResource.json
@@ -1,8 +1,12 @@
 {
   "description": "Describes an implanted embryo.",
 
-  "allOf": [{
+  "allOf": [
+    {
       "$ref": "../resources/icarResource.json"
+    },
+    {
+      "$ref": "../types/icarReproSireInfoType.json"
     },
     {
       "type": "object",
@@ -30,25 +34,6 @@
         "donorURI": {
           "type": "string",
           "description": "URI to an AnimalCoreResource for the donor dam."
-        },
-        "sireIdentifiers": {
-          "type": "array",
-          "items": {
-            "$ref": "../types/icarAnimalIdentifierType.json"
-          },
-          "description": "One or more unique scheme/identifier combinations for the sire."
-        },
-        "sireOfficialName": {
-          "type": "string",
-          "description": "Official herdbook name of the sire."
-        },
-        "sireURI": {
-          "type": "string",
-          "description": "URI to an AnimalCoreResource for the sire."
-        },
-        "sirePrimaryBreed": {
-          "$ref": "../types/icarBreedIdentifierType.json",
-          "description": "ICAR Breed code for the sire. The usage of this property is not reasonable if more than one sire is provided."
         }
       }
     }

--- a/resources/icarReproInseminationEventResource.json
+++ b/resources/icarReproInseminationEventResource.json
@@ -1,8 +1,12 @@
 {
   "description": "Event for recording natural or artificial insemination, including embryo transfer.",
 
-  "allOf": [{
+  "allOf": [
+    {
       "$ref": "../resources/icarAnimalEventCoreResource.json"
+    },
+    {
+      "$ref": "../types/icarReproSireInfoType.json"
     },
     {
       "type": "object",
@@ -18,25 +22,6 @@
         },
         "inseminationType": {
           "$ref": "../enums/icarReproInseminationType.json"
-        },
-        "sireIdentifiers": {
-          "type": "array",
-          "items": {
-            "$ref": "../types/icarAnimalIdentifierType.json"
-          },
-          "description": "Unique scheme/identifier combinations for the sire, including official ID and Herdbook."
-        },
-        "sireOfficialName": {
-          "type": "string",
-          "description": "Official herdbook name of the sire."
-        },
-        "sireURI": {
-          "type": "string",
-          "description": "URI to an AnimalCoreResource for the sire."
-        },
-        "sirePrimaryBreed": {
-          "$ref": "../types/icarBreedIdentifierType.json",
-          "description": "ICAR Breed code for the sire. The usage of this property is not reasonable if more than one sire is provided."
         },
         "straw": {
           "$ref": "../resources/icarReproSemenStrawResource.json",

--- a/resources/icarReproSemenStrawResource.json
+++ b/resources/icarReproSemenStrawResource.json
@@ -1,8 +1,12 @@
 {
   "description": "Describes a semen straw",
 
-  "allOf": [{
+  "allOf": [
+    {
       "$ref": "../resources/icarResource.json"
+    },
+    {
+      "$ref": "../types/icarReproSireInfoType.json"
     },
     {
       "type": "object",
@@ -23,25 +27,6 @@
         "dateCollected": {
           "description": "RFC3339 UTC date/time of collection (see https://ijmacd.github.io/rfc3339-iso8601/ for format guidance).",
           "$ref": "../types/icarDateTimeType.json"
-        },
-        "sireIdentifiers": {
-          "type": "array",
-          "items": {
-            "$ref": "../types/icarAnimalIdentifierType.json"
-          },
-          "description": "One or more unique scheme/identifier combinations for the sire."
-        },
-        "sireOfficialName": {
-          "type": "string",
-          "description": "Official herdbook name of the sire."
-        },
-        "sireURI": {
-          "type": "string",
-          "description": "URI to an AnimalCoreResource for the sire."
-        },
-        "sirePrimaryBreed": {
-          "$ref": "../types/icarBreedIdentifierType.json",
-          "description": "ICAR Breed code for the sire. The usage of this property is not reasonable if more than one sire is provided."
         },
         "preservationType": {
           "$ref": "../enums/icarReproSemenPreservationType.json",

--- a/types/icarReproSireInfoType.json
+++ b/types/icarReproSireInfoType.json
@@ -21,7 +21,7 @@
     },
     "sirePrimaryBreed": {
       "$ref": "../types/icarBreedIdentifierType.json",
-      "description": "ICAR Breed code for the sire. The usage of this property is not reasonable if more than one sire is provided."
+      "description": "ICAR Breed code for the sire referenced by the sireIdentifiers. If more than one sire is identified, do not specify the breed unless all sires have the same primary breed."
     }
   }
 }

--- a/types/icarReproSireInfoType.json
+++ b/types/icarReproSireInfoType.json
@@ -1,5 +1,5 @@
 {
-  "description": "Describes sire information related to a reproductive event.",
+  "description": "Describes sire information used in reproductive contexts.",
 
   "type": "object",
 

--- a/types/icarReproSireInfoType.json
+++ b/types/icarReproSireInfoType.json
@@ -1,0 +1,27 @@
+{
+  "description": "Describes sire information related to a reproductive event.",
+
+  "type": "object",
+
+  "properties": {
+    "sireIdentifiers": {
+      "type": "array",
+      "items": {
+        "$ref": "../types/icarAnimalIdentifierType.json"
+      },
+      "description": "One or more unique scheme/identifier combinations for the sire."
+    },
+    "sireOfficialName": {
+      "type": "string",
+      "description": "Official herdbook name of the sire."
+    },
+    "sireURI": {
+      "type": "string",
+      "description": "URI to an AnimalCoreResource for the sire."
+    },
+    "sirePrimaryBreed": {
+      "$ref": "../types/icarBreedIdentifierType.json",
+      "description": "ICAR Breed code for the sire. The usage of this property is not reasonable if more than one sire is provided."
+    }
+  }
+}

--- a/types/icarSireRecommendationType.json
+++ b/types/icarSireRecommendationType.json
@@ -1,42 +1,34 @@
 {
   "description": "Gives one possible sire recommended to use on an animal.",
 
-  "type": "object",
+  "allOf": [
+    {
+      "$ref": "../types/icarReproSireInfoType.json"
+    },
+    {
+      "type": "object",
 
-  "properties": {
-    "recommendationType": {
-      "$ref": "../enums/icarRecommendationType.json"
-    },
-    "sireIdentifiers": {
-      "type": "array",
-      "items": {
-        "$ref": "../types/icarAnimalIdentifierType.json"
-      },
-      "description": "Unique scheme/identifier combinations for the sire, including official ID and Herdbook."
-    },
-    "sireOfficialName": {
-      "type": "string",
-      "description": "Official herdbook name of the sire."
-    },
-    "sireURI": {
-      "type": "string",
-      "description": "URI to an AnimalCoreResource for the sire."
-    },
-    "isSexedSemen": {
-      "type": "boolean",
-      "description": "True if this is sexed semen."
-    },
-    "sexedGender": {
-      "$ref": "../enums/icarAnimalGenderType.json",
-      "description": "Specify Male or Female for sexed semen only."
-    },
-    "parity": {
-      "type": "integer",
-      "description": "The parity of the cow for which the recommendation is valid."
-    },
-    "sireRank": {
-      "type": "integer",
-      "description": "The rank of the sire in the recommendation, 1 = first choice, 2 = second, ...."
+      "properties": {
+        "recommendationType": {
+          "$ref": "../enums/icarRecommendationType.json"
+        },
+        "isSexedSemen": {
+          "type": "boolean",
+          "description": "True if this is sexed semen."
+        },
+        "sexedGender": {
+          "$ref": "../enums/icarAnimalGenderType.json",
+          "description": "Specify Male or Female for sexed semen only."
+        },
+        "parity": {
+          "type": "integer",
+          "description": "The parity of the cow for which the recommendation is valid."
+        },
+        "sireRank": {
+          "type": "integer",
+          "description": "The rank of the sire in the recommendation, 1 = first choice, 2 = second, ...."
+        }
+      }
     }
-  }
+  ]
 }


### PR DESCRIPTION
Update the insemination event and related reproductive resources with icarReproSireInfoType to clarify the related sire identifier and breed fields. Resolves #563 