### PR TITLE
Add device to icarObservationSummaryResource

### DIFF
--- a/resources/icarObservationSummaryResource.json
+++ b/resources/icarObservationSummaryResource.json
@@ -21,10 +21,10 @@
             "items": {
               "$ref": "../types/icarObservationStatisticsType.json"
             }
-          },                   
+          },
           "device": {
-              "$ref": "../types/icarDeviceReferenceType.json",
-              "description": "Identifies the device that recorded the observations."
+            "$ref": "../types/icarDeviceReferenceType.json",
+            "description": "Identifies the device that recorded the observations."
           }
         }
       }

--- a/resources/icarObservationSummaryResource.json
+++ b/resources/icarObservationSummaryResource.json
@@ -21,7 +21,11 @@
             "items": {
               "$ref": "../types/icarObservationStatisticsType.json"
             }
-          }                   
+          },                   
+          "device": {
+              "$ref": "../types/icarDeviceReferenceType.json",
+              "description": "Identifies the device that recorded the observations."
+          }
         }
       }
     ]


### PR DESCRIPTION
Add `device`, an `icarDeviceReferenceType` so we can identify the source of the observation(s). Resolves #612