### PR TITLE
Add milk destination

### DIFF
--- a/enums/icarMilkDestinationType.json
+++ b/enums/icarMilkDestinationType.json
@@ -1,0 +1,14 @@
+{
+    "description": "Define the destination of milk from a cluster (or in the future, even a quarter)",
+    "type": "string",
+    "enum" : [
+        "MilkTank",
+        "Separation1",
+        "Separation2",
+        "Discard",
+        "Colostrum",
+        "Transition",
+        "Progeny",
+        "Treatment"
+    ]
+}

--- a/resources/icarMilkingVisitEventResource.json
+++ b/resources/icarMilkingVisitEventResource.json
@@ -59,6 +59,10 @@
           "type": "integer",
           "description": "For milkings supervised by humans, this number represents the shift within a local date in which this milking visit occurred." 
         },
+        "milkDestination": {
+          "description": "The destination of the milk from this milking visit.",
+          "$ref": "../enums/icarMilkDestinationType.json"
+        },
         "quarterMilkings": {
           "description": "A set of milking results for up to four quarters in dairy cows, or two teats for sheep or goats.",
           "type": "array",

--- a/types/icarQuarterMilkingType.json
+++ b/types/icarQuarterMilkingType.json
@@ -38,6 +38,9 @@
         "$ref": "../types/icarQuarterMilkingSampleType.json"
       }
     },
+    "milkDestination": {
+      "$ref": "../enums/icarMilkDestinationType.json"
+    },
     "icarQuarterCharacteristics": {
       "type": "array",
       "items": {


### PR DESCRIPTION
Add milk destination (`īcarMilkDestinationType`) to `icarMilkingVisitEventResource` and `icarQuarterMilkingType` (the latter seems unlikely until equipment supports milking destination by quarter, but it is optional). Resolves #605