### PR TITLE
Add X-ADE-Version and X-ADE-AcceptVersion headers and tidy OpenAPI specs

### DIFF
--- a/url-schemes/exampleUrlScheme.json
+++ b/url-schemes/exampleUrlScheme.json
@@ -63,9 +63,19 @@
         "tags": [
           "ADE-1.5-registration"
         ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the available locations.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -105,6 +115,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/meta-modified-to"
+                    },
+                    {
+                      "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
@@ -143,11 +156,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the milking results for the given location",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -186,11 +207,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the test days for the given location",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -229,11 +258,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the test day results for the given location",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -273,11 +310,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/meta-modified-to"
+                    },
+                    {
+                      "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the milk predictions for the given location.",
+                        "headers": {
+                          "X-ADE-Version": {
+                            "$ref": "#/components/headers/X-ADE-Version"
+                          }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -311,11 +356,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the daily averages per animal for the given location",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -343,11 +396,19 @@
           },
           {
             "$ref": "#/components/parameters/location-id"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the milking results for the given location",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -381,11 +442,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the milking results for the given location",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -419,11 +488,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the births for the given location",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -457,11 +534,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the died animals for the given location",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },  
             "content": {
               "application/json": {
                 "schema": {
@@ -495,11 +580,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the arrived animals for the given location",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -538,11 +631,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the milking results for the given location",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -575,6 +676,11 @@
         "responses": {
           "200": {
             "description": "Successful. The response contains the animals for the given location",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -605,11 +711,19 @@
             "$ref": "#/components/parameters/animal-scheme"
           }, {
             "$ref": "#/components/parameters/animal-id"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the animal sets for the given location",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -649,11 +763,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the join animal set events of animals for the given location",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -693,11 +815,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the leave animal set events of animals for the given location",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -735,6 +865,11 @@
         "responses": {
           "200": {
             "description": "Successful. The response contains the service sires matching your query parameters",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -772,11 +907,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/purpose"
+                    },
+                    {
+                      "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }                    
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the statistics for the given location.",
+                        "headers": {
+                          "X-ADE-Version": {
+                            "$ref": "#/components/headers/X-ADE-Version"
+                          }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -810,11 +953,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the pregnancy diagnosis for the given location",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -853,11 +1004,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the heats for the given location",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -891,11 +1050,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the inseminations for the given location",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -934,11 +1101,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the drying off for the given location",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -980,11 +1155,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the abortion events for the given location",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -1018,11 +1201,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the not to be bred animals for the given location",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -1056,11 +1247,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the Parturition events for the given location",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -1094,11 +1293,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the flushing events for the given location",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -1132,11 +1339,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the weight results for the given location",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -1170,11 +1385,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the device data for the given location",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -1208,11 +1431,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the feed storage device data for the given location",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -1251,11 +1482,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the breeding values of the animals of the given location",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -1289,11 +1528,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the mating recommendations for the given location",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -1327,11 +1574,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the conformation scores for the given location",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -1366,11 +1621,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/meta-modified-to"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the resources for the given location.",
+                        "headers": {
+                          "X-ADE-Version": {
+                            "$ref": "#/components/headers/X-ADE-Version"
+                          }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1404,11 +1667,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the diagnoses for the given location.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -1442,11 +1713,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the treatments for the given location.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -1480,11 +1759,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the treatment progams for the given location.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -1519,11 +1806,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the treatment progams for the given location.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -1557,11 +1852,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the gestations for the given location.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -1595,11 +1898,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the feeds for the given location.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -1633,11 +1944,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the rations for the given location.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -1671,11 +1990,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the feed intakes for the given location.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -1710,11 +2037,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the feed intakes for the given location.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -1748,11 +2083,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the feed intakes for the given location.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -1787,11 +2130,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the rations for the given location.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -1831,11 +2182,19 @@
           },
           {
             "$ref": "#/components/parameters/report-end-date-time"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
          ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the feed reports for animals on the given location.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -1869,11 +2228,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the reproductive status change observations for the given location.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -1896,9 +2263,19 @@
         "tags": [
           "ADE-1.5-scheme"
         ],
+        "parameters": [
+          {
+              "$ref": "#/components/parameters/X-ADE-AcceptVersion"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the supported schemata.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -1929,11 +2306,19 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/scheme-type"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the supported schemes for the specified scheme type.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -1970,11 +2355,19 @@
           },
           {
             "$ref": "#/components/parameters/scheme"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the values for the specified scheme and scheme type.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -2007,11 +2400,19 @@
           },
           {
             "$ref": "#/components/parameters/location-id"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the suppoted schemata for the given location.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -2047,11 +2448,19 @@
           },
           {
             "$ref": "#/components/parameters/scheme-type"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the suppoted scheme for specific scheme type for the given location.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -2093,11 +2502,19 @@
           },
           {
             "$ref": "#/components/parameters/scheme"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the suppoted scheme for specific scheme type for the given location.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -2137,11 +2554,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the treatments for the given location.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -2176,11 +2601,19 @@
               },
               {
                   "$ref": "#/components/parameters/meta-modified-to"
+              },
+              {
+                  "$ref": "#/components/parameters/X-ADE-AcceptVersion"
               }
           ],
           "responses": {
               "200": {
                   "description": "Successful. The response contains the resources for the given location.",
+                  "headers": {
+                      "X-ADE-Version": {
+                          "$ref": "#/components/headers/X-ADE-Version"
+                      }
+                  },
                   "content": {
                       "application/json": {
                           "schema": {
@@ -2215,11 +2648,19 @@
               },
               {
                   "$ref": "#/components/parameters/meta-modified-to"
+              },
+              {
+                  "$ref": "#/components/parameters/X-ADE-AcceptVersion"
               }
           ],
           "responses": {
               "200": {
                   "description": "Successful. The response contains the arrival events for the given location.",
+                  "headers": {
+                      "X-ADE-Version": {
+                          "$ref": "#/components/headers/X-ADE-Version"
+                      }
+                  },
                   "content": {
                       "application/json": {
                           "schema": {
@@ -2254,11 +2695,19 @@
               },
               {
                   "$ref": "#/components/parameters/meta-modified-to"
+              },
+              {
+                  "$ref": "#/components/parameters/X-ADE-AcceptVersion"
               }
           ],
           "responses": {
               "200": {
                   "description": "Successful. The response contains the birth or initial registration events for the given location.",
+                  "headers": {
+                      "X-ADE-Version": {
+                          "$ref": "#/components/headers/X-ADE-Version"
+                      }
+                  },
                   "content": {
                       "application/json": {
                           "schema": {
@@ -2293,11 +2742,19 @@
               },
               {
                   "$ref": "#/components/parameters/meta-modified-to"
+              },
+              {
+                  "$ref": "#/components/parameters/X-ADE-AcceptVersion"
               }
           ],
           "responses": {
               "200": {
                   "description": "Successful. The response contains the group death events for the given location.",
+                  "headers": {
+                      "X-ADE-Version": {
+                          "$ref": "#/components/headers/X-ADE-Version"
+                      }
+                  },
                   "content": {
                       "application/json": {
                           "schema": {
@@ -2332,11 +2789,19 @@
               },
               {
                   "$ref": "#/components/parameters/meta-modified-to"
+              },
+              {
+                  "$ref": "#/components/parameters/X-ADE-AcceptVersion"
               }
           ],
           "responses": {
               "200": {
                   "description": "Successful. The response contains the group departure events for the given location.",
+                  "headers": {
+                      "X-ADE-Version": {
+                          "$ref": "#/components/headers/X-ADE-Version"
+                      }
+                  },
                   "content": {
                       "application/json": {
                           "schema": {
@@ -2371,11 +2836,19 @@
               },
               {
                   "$ref": "#/components/parameters/meta-modified-to"
+              },
+              {
+                  "$ref": "#/components/parameters/X-ADE-AcceptVersion"
               }
           ],
           "responses": {
               "200": {
                   "description": "Successful. The response contains the group departure events for the given location.",
+                  "headers": {
+                      "X-ADE-Version": {
+                          "$ref": "#/components/headers/X-ADE-Version"
+                      }
+                  },
                   "content": {
                       "application/json": {
                           "schema": {
@@ -2410,11 +2883,19 @@
               },
               {
                   "$ref": "#/components/parameters/meta-modified-to"
+              },
+              {
+                  "$ref": "#/components/parameters/X-ADE-AcceptVersion"
               }
           ],
           "responses": {
               "200": {
                   "description": "Successful. The response contains the group departure events for the given location.",
+                  "headers": {
+                      "X-ADE-Version": {
+                          "$ref": "#/components/headers/X-ADE-Version"
+                      }
+                  },
                   "content": {
                       "application/json": {
                           "schema": {
@@ -2449,11 +2930,19 @@
               },
               {
                   "$ref": "#/components/parameters/meta-modified-to"
+              },
+              {
+                  "$ref": "#/components/parameters/X-ADE-AcceptVersion"
               }
           ],
           "responses": {
               "200": {
                   "description": "Successful. The response contains the group departure events for the given location.",
+                  "headers": {
+                      "X-ADE-Version": {
+                          "$ref": "#/components/headers/X-ADE-Version"
+                      }
+                  },
                   "content": {
                       "application/json": {
                           "schema": {
@@ -2503,11 +2992,19 @@
               },
               {
                   "$ref": "#/components/parameters/meta-modified-to"
+              },
+              {
+                  "$ref": "#/components/parameters/X-ADE-AcceptVersion"
               }
           ],
           "responses": {
               "200": {
                   "description": "Successful. The response contains the inventory transactions for the given location.",
+                  "headers": {
+                      "X-ADE-Version": {
+                          "$ref": "#/components/headers/X-ADE-Version"
+                      }
+                  },
                   "content": {
                       "application/json": {
                           "schema": {
@@ -2554,11 +3051,19 @@
               },
               {
                   "$ref": "#/components/parameters/meta-modified-to"
+              },
+              {
+                  "$ref": "#/components/parameters/X-ADE-AcceptVersion"
               }
           ],
           "responses": {
               "200": {
                   "description": "Successful. The response contains the feed inventory transactions for the given location.",
+                  "headers": {
+                      "X-ADE-Version": {
+                          "$ref": "#/components/headers/X-ADE-Version"
+                      }
+                  },
                   "content": {
                       "application/json": {
                           "schema": {
@@ -2605,11 +3110,19 @@
               },
               {
                   "$ref": "#/components/parameters/meta-modified-to"
+              },
+              {
+                  "$ref": "#/components/parameters/X-ADE-AcceptVersion"
               }
           ],
           "responses": {
               "200": {
                   "description": "Successful. The response contains the medicine inventory transactions for the given location.",
+                  "headers": {
+                      "X-ADE-Version": {
+                          "$ref": "#/components/headers/X-ADE-Version"
+                      }
+                  },
                   "content": {
                       "application/json": {
                           "schema": {
@@ -2656,11 +3169,19 @@
               },
               {
                   "$ref": "#/components/parameters/meta-modified-to"
+              },
+              {
+                  "$ref": "#/components/parameters/X-ADE-AcceptVersion"
               }
           ],
           "responses": {
               "200": {
                   "description": "Successful. The response contains the attention event resources for the given location.",
+                  "headers": {
+                      "X-ADE-Version": {
+                          "$ref": "#/components/headers/X-ADE-Version"
+                      }
+                  },
                   "content": {
                       "application/json": {
                           "schema": {
@@ -2707,11 +3228,19 @@
               },
               {
                   "$ref": "#/components/parameters/meta-modified-to"
+              },
+              {
+                  "$ref": "#/components/parameters/X-ADE-AcceptVersion"
               }
           ],
           "responses": {
               "200": {
                   "description": "Successful. The response contains the animal position observation events for the given location.",
+                  "headers": {
+                      "X-ADE-Version": {
+                          "$ref": "#/components/headers/X-ADE-Version"
+                      }
+                  },
                   "content": {
                       "application/json": {
                           "schema": {
@@ -2758,11 +3287,19 @@
               },
               {
                   "$ref": "#/components/parameters/meta-modified-to"
+              },
+              {
+                  "$ref": "#/components/parameters/X-ADE-AcceptVersion"
               }
           ],
           "responses": {
               "200": {
                   "description": "Successful. The response contains the animal position observation events for the given location.",
+                  "headers": {
+                      "X-ADE-Version": {
+                          "$ref": "#/components/headers/X-ADE-Version"
+                      }
+                  },
                   "content": {
                       "application/json": {
                           "schema": {
@@ -2818,11 +3355,19 @@
               },
               {
                   "$ref": "#/components/parameters/meta-modified-to"
+              },
+              {
+                  "$ref": "#/components/parameters/X-ADE-AcceptVersion"
               }
           ],
           "responses": {
               "200": {
                   "description": "Successful. The response contains the animal observation summary resources for the given location.",
+                  "headers": {
+                      "X-ADE-Version": {
+                          "$ref": "#/components/headers/X-ADE-Version"
+                      }
+                  },
                   "content": {
                       "application/json": {
                           "schema": {
@@ -2856,11 +3401,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+              "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the remark events for the given location.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -2894,11 +3447,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+              "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the weaning events for the given location.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -2932,11 +3493,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+              "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the group weaning events for the given location.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -3153,7 +3722,24 @@
         "$ref": "../collections/icarGroupWeaningEventCollection.json"
       }
     },
+    "headers": {
+      "X-ADE-Version": {
+        "description": "The version of the ADE specification.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    },
     "parameters": {
+      "X-ADE-AcceptVersion": {
+        "name": "X-ADE-AcceptVersion",
+        "in": "header",
+        "description": "The version of the ADE specification that the client accepts.",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
       "location-scheme": {
         "name": "location-scheme",
         "in": "path",

--- a/url-schemes/exampleUrlScheme.json
+++ b/url-schemes/exampleUrlScheme.json
@@ -671,6 +671,9 @@
           },
           {
             "$ref": "#/components/parameters/location-id"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
@@ -860,6 +863,9 @@
           },
           {
             "$ref": "#/components/parameters/identifier-id"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {

--- a/url-schemes/feedURLscheme.json
+++ b/url-schemes/feedURLscheme.json
@@ -42,11 +42,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/meta-modified-to"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the resources for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -73,6 +81,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -89,6 +100,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -98,28 +114,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -147,11 +145,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/meta-modified-to"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the resources for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -178,6 +184,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -194,6 +203,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -203,28 +217,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -258,11 +254,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/animal-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the resources for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -289,6 +293,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -305,6 +312,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -314,28 +326,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -369,11 +363,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/animal-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the resources for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -400,6 +402,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -416,6 +421,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -425,28 +435,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -480,11 +472,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/report-end-date-time"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the feed reports for animals on the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -519,11 +519,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/meta-modified-to"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the resources for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -555,6 +563,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -571,6 +582,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -580,28 +596,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -641,11 +639,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/meta-modified-to"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the feed inventory transactions for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -672,6 +678,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -688,6 +697,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -697,28 +711,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -747,11 +743,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/meta-modified-to"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the resources for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -779,6 +783,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -795,6 +802,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modified by the server.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -804,28 +816,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -853,11 +847,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/meta-modified-to"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the resources for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -884,6 +886,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -900,6 +905,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -909,28 +919,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -952,6 +944,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -968,6 +963,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -977,38 +977,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -1027,6 +1002,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -1043,6 +1021,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1052,38 +1035,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -1102,6 +1060,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -1118,6 +1079,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1127,38 +1093,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -1177,6 +1118,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -1193,6 +1137,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1202,38 +1151,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -1252,6 +1176,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -1268,6 +1195,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1277,38 +1209,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -1327,6 +1234,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -1343,6 +1253,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1352,38 +1267,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }    
@@ -1402,6 +1292,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -1418,6 +1311,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1427,38 +1325,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -1559,6 +1432,14 @@
                     "$ref": "#/components/schemas/icarGroupFeedingEventResource"
                 }
             }        
+        },
+        "headers": {
+            "X-ADE-Version": {
+                "description": "The version of the ADE specification.",
+                "schema": {
+                    "type": "string"
+                }
+            }
         },
         "parameters": {
             "location-scheme": {
@@ -1668,19 +1549,78 @@
                 "schema": {
                     "type": "string"
                 }
+            },
+            "X-ADE-AcceptVersion": {
+                "name": "X-ADE-AcceptVersion",
+                "in": "header",
+                "description": "The version of the ADE specification that the client accepts.",
+                "required": false,
+                "schema": {
+                    "type": "string"
+                }
             }
         },
         "responses": {
-          "default": {
-            "description": "An error has occured while handling the request. Check the content of the message for the error details.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "../collections/icarErrorCollection.json"
+            "default": {
+                "description": "An error has occured while handling the request. Check the content of the message for the error details.",
+                "headers": {
+                "X-ADE-Version": {
+                    "$ref": "#/components/headers/X-ADE-Version"
                 }
-              }
+                },
+                "content": {
+                "application/json": {
+                    "schema": {
+                    "$ref": "../collections/icarErrorCollection.json"
+                    }
+                }
+                }
+            },
+            "batchdefault": {
+                "description": "The response contains a set of batch results, which may include errors and warnings.",
+                "headers": {
+                    "X-ADE-Version": {
+                        "$ref": "#/components/headers/X-ADE-Version"
+                    }
+                },
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/batchResults"
+                        }
+                    }
+                }
+            },
+            "createdresponse": {
+                "description": "Created. The Location header contains the URI to the new resource.",
+                "headers": {
+                    "Location": {
+                        "schema": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "description": "Contains the URI to the new resource."
+                    },
+                    "X-ADE-Version": {
+                        "$ref": "#/components/headers/X-ADE-Version"
+                    }
+                }
+            },
+            "acceptedresponse": {
+                "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
+                "headers": {
+                    "Location": {
+                        "schema": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "description": "Contains a URI to query creation status."
+                    },
+                    "X-ADE-Version": {
+                        "$ref": "#/components/headers/X-ADE-Version"
+                    }
+                }
             }
-          }
         },
         "examples": {
             "feed-storages": {

--- a/url-schemes/healthURLScheme.json
+++ b/url-schemes/healthURLScheme.json
@@ -48,11 +48,19 @@
           },
           {
             "$ref": "#/components/parameters/animal-id"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the diagnoses for the given location.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -95,6 +103,11 @@
         "responses": {
           "200": {
             "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -104,28 +117,10 @@
             }
           },
           "201": {
-            "description": "Created. The Location header contains the URI to the new resource.",
-            "headers": {
-              "Location": {
-                "schema": {
-                  "type": "string",
-                  "format": "uri"
-                },
-                "description": "Contains the URI to the new resource."
-              }
-            }
+              "$ref": "#/components/responses/createdresponse"
           },
           "202": {
-            "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-            "headers": {
-              "Location": {
-                "schema": {
-                  "type": "string",
-                  "format": "uri"
-                },
-                "description": "Contains a URI to query creation status."
-              }
-            }
+              "$ref": "#/components/responses/acceptedresponse"
           },
           "default": {
             "$ref": "#/components/responses/default"
@@ -159,11 +154,19 @@
           },
           {
             "$ref": "#/components/parameters/animal-id"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the treatments for the given location.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -190,6 +193,9 @@
           },
           {
             "$ref": "#/components/parameters/location-id"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "requestBody": {
@@ -206,6 +212,11 @@
         "responses": {
           "200": {
             "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -215,10 +226,10 @@
             }
           },
           "201": {
-            "description": "Created. The Location header contains the URI to the new resource."
+              "$ref": "#/components/responses/createdresponse"
           },
           "202": {
-            "description": "Accepted. The Location header contains a URI that the client can query for processing status."
+              "$ref": "#/components/responses/acceptedresponse"
           },
           "default": {
             "$ref": "#/components/responses/default"
@@ -246,11 +257,19 @@
           },
           {
             "$ref": "#/components/parameters/meta-modified-to"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the treatments for the given location.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -277,6 +296,9 @@
           },
           {
             "$ref": "#/components/parameters/location-id"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "requestBody": {
@@ -293,6 +315,11 @@
         "responses": {
           "200": {
             "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -302,10 +329,10 @@
             }
           },
           "201": {
-            "description": "Created. The Location header contains the URI to the new resource."
+            "$ref": "#/components/responses/createdresponse"
           },
           "202": {
-            "description": "Accepted. The Location header contains a URI that the client can query for processing status."
+            "$ref": "#/components/responses/acceptedresponse"
           },
           "default": {
             "$ref": "#/components/responses/default"
@@ -339,11 +366,19 @@
           },
           {
             "$ref": "#/components/parameters/animal-id"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the treatment progams for the given location.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -370,6 +405,9 @@
           },
           {
             "$ref": "#/components/parameters/location-id"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "requestBody": {
@@ -386,6 +424,11 @@
         "responses": {
           "200": {
             "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -395,10 +438,10 @@
             }
           },
           "201": {
-            "description": "Created. The Location header contains the URI to the new resource."
+            "$ref": "#/components/responses/createdresponse"
           },
           "202": {
-            "description": "Accepted. The Location header contains a URI that the client can query for processing status."
+            "$ref": "#/components/responses/acceptedresponse"
           },
           "default": {
             "$ref": "#/components/responses/default"
@@ -432,11 +475,19 @@
           },
           {
             "$ref": "#/components/parameters/animal-id"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the treatment progams for the given location.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -463,6 +514,9 @@
           },
           {
             "$ref": "#/components/parameters/location-id"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "requestBody": {
@@ -479,6 +533,11 @@
         "responses": {
           "200": {
             "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -488,10 +547,10 @@
             }
           },
           "201": {
-            "description": "Created. The Location header contains the URI to the new resource."
+            "$ref": "#/components/responses/createdresponse"
           },
           "202": {
-            "description": "Accepted. The Location header contains a URI that the client can query for processing status."
+            "$ref": "#/components/responses/acceptedresponse"
           },
           "default": {
             "$ref": "#/components/responses/default"
@@ -537,11 +596,19 @@
           },
           {
             "$ref": "#/components/parameters/animal-id"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the medicine inventory transactions for the given location.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -568,6 +635,9 @@
           },
           {
             "$ref": "#/components/parameters/location-id"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "requestBody": {
@@ -584,6 +654,11 @@
         "responses": {
           "200": {
             "description": "Successful. The response contains a copy of the resource, as modifed by the server.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -593,10 +668,10 @@
             }
           },
           "201": {
-            "description": "Created. The Location header contains the URI to the new resource."
+            "$ref": "#/components/responses/createdresponse"
           },
           "202": {
-            "description": "Accepted. The Location header contains a URI that the client can query for processing status."
+            "$ref": "#/components/responses/acceptedresponse"
           },
           "default": {
             "$ref": "#/components/responses/default"
@@ -642,11 +717,19 @@
           },
           {
             "$ref": "#/components/parameters/animal-id"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the attention event resources for the given location.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -673,6 +756,9 @@
           },
           {
             "$ref": "#/components/parameters/location-id"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "requestBody": {
@@ -689,6 +775,11 @@
         "responses": {
           "200": {
             "description": "Successful. The response contains a copy of the resource, as modifed by the server.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -698,10 +789,10 @@
             }
           },
           "201": {
-            "description": "Created. The Location header contains the URI to the new resource."
+            "$ref": "#/components/responses/createdresponse"
           },
           "202": {
-            "description": "Accepted. The Location header contains a URI that the client can query for processing status."
+            "$ref": "#/components/responses/acceptedresponse"
           },
           "default": {
             "$ref": "#/components/responses/default"
@@ -723,6 +814,9 @@
           },
           {
             "$ref": "#/components/parameters/location-id"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "requestBody": {
@@ -739,6 +833,11 @@
         "responses": {
           "200": {
             "description": "Successful. The response contains a set of batch results, which may include warnings.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -748,38 +847,13 @@
             }
           },
           "201": {
-            "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-            "headers": {
-              "Location": {
-                "schema": {
-                  "type": "string",
-                  "format": "uri"
-                },
-                "description": "Contains the URI to the results."
-              }
-            }
+            "$ref": "#/components/responses/createdresponse"
           },
           "202": {
-            "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-            "headers": {
-              "Location": {
-                "schema": {
-                  "type": "string",
-                  "format": "uri"
-                },
-                "description": "Contains a URI to query creation status."
-              }
-            }
+            "$ref": "#/components/responses/acceptedresponse"
           },
           "default": {
-            "description": "The response contains a set of batch results, which may include errors and warnings.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/batchResults"
-                }
-              }
-            }
+            "$ref": "#/components/responses/batchdefault"
           }
         }
       }
@@ -798,6 +872,9 @@
           },
           {
             "$ref": "#/components/parameters/location-id"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "requestBody": {
@@ -814,6 +891,11 @@
         "responses": {
           "200": {
             "description": "Successful. The response contains a set of batch results, which may include warnings.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -823,38 +905,13 @@
             }
           },
           "201": {
-            "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-            "headers": {
-              "Location": {
-                "schema": {
-                  "type": "string",
-                  "format": "uri"
-                },
-                "description": "Contains the URI to the results."
-              }
-            }
+              "$ref": "#/components/responses/createdresponse"
           },
           "202": {
-            "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-            "headers": {
-              "Location": {
-                "schema": {
-                  "type": "string",
-                  "format": "uri"
-                },
-                "description": "Contains a URI to query creation status."
-              }
-            }
+              "$ref": "#/components/responses/acceptedresponse"
           },
           "default": {
-            "description": "The response contains a set of batch results, which may include errors and warnings.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/batchResults"
-                }
-              }
-            }
+            "$ref": "#/components/responses/batchdefault"
           }
         }
       }
@@ -873,6 +930,9 @@
           },
           {
             "$ref": "#/components/parameters/location-id"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "requestBody": {
@@ -889,6 +949,11 @@
         "responses": {
           "200": {
             "description": "Successful. The response contains a set of batch results, which may include warnings.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -898,38 +963,13 @@
             }
           },
           "201": {
-            "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-            "headers": {
-              "Location": {
-                "schema": {
-                  "type": "string",
-                  "format": "uri"
-                },
-                "description": "Contains the URI to the results."
-              }
-            }
+              "$ref": "#/components/responses/createdresponse"
           },
           "202": {
-            "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-            "headers": {
-              "Location": {
-                "schema": {
-                  "type": "string",
-                  "format": "uri"
-                },
-                "description": "Contains a URI to query creation status."
-              }
-            }
+              "$ref": "#/components/responses/acceptedresponse"
           },
           "default": {
-            "description": "The response contains a set of batch results, which may include errors and warnings.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/batchResults"
-                }
-              }
-            }
+            "$ref": "#/components/responses/batchdefault"
           }
         }
       }
@@ -948,6 +988,9 @@
           },
           {
             "$ref": "#/components/parameters/location-id"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "requestBody": {
@@ -964,6 +1007,11 @@
         "responses": {
           "200": {
             "description": "Successful. The response contains a set of batch results, which may include warnings.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -973,38 +1021,13 @@
             }
           },
           "201": {
-            "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-            "headers": {
-              "Location": {
-                "schema": {
-                  "type": "string",
-                  "format": "uri"
-                },
-                "description": "Contains the URI to the results."
-              }
-            }
+            "$ref": "#/components/responses/createdresponse"
           },
           "202": {
-            "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-            "headers": {
-              "Location": {
-                "schema": {
-                  "type": "string",
-                  "format": "uri"
-                },
-                "description": "Contains a URI to query creation status."
-              }
-            }
+            "$ref": "#/components/responses/acceptedresponse"
           },
           "default": {
-            "description": "The response contains a set of batch results, which may include errors and warnings.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/batchResults"
-                }
-              }
-            }
+            "$ref": "#/components/responses/batchdefault"
           }
         }
       }
@@ -1023,6 +1046,9 @@
           },
           {
             "$ref": "#/components/parameters/location-id"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "requestBody": {
@@ -1039,6 +1065,11 @@
         "responses": {
           "200": {
             "description": "Successful. The response contains a set of batch results, which may include warnings.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -1048,38 +1079,13 @@
             }
           },
           "201": {
-            "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-            "headers": {
-              "Location": {
-                "schema": {
-                  "type": "string",
-                  "format": "uri"
-                },
-                "description": "Contains the URI to the results."
-              }
-            }
+            "$ref": "#/components/responses/createdresponse"
           },
           "202": {
-            "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-            "headers": {
-              "Location": {
-                "schema": {
-                  "type": "string",
-                  "format": "uri"
-                },
-                "description": "Contains a URI to query creation status."
-              }
-            }
+            "$ref": "#/components/responses/acceptedresponse"
           },
           "default": {
-            "description": "The response contains a set of batch results, which may include errors and warnings.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/batchResults"
-                }
-              }
-            }
+            "$ref": "#/components/responses/batchdefault"
           }
         }
       }
@@ -1098,6 +1104,9 @@
               },
               {
                   "$ref": "#/components/parameters/location-id"
+              },
+              {
+                "$ref": "#/components/parameters/X-ADE-AcceptVersion"
               }
           ],
           "requestBody": {
@@ -1114,6 +1123,11 @@
           "responses": {
               "200": {
                   "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                  "headers": {
+                    "X-ADE-Version": {
+                      "$ref": "#/components/headers/X-ADE-Version"
+                    }
+                  },
                   "content": {
                       "application/json": {
                           "schema": {
@@ -1123,38 +1137,13 @@
                   }
               },
               "201": {
-                  "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                  "headers": {
-                      "Location": {
-                          "schema": {
-                              "type": "string",
-                              "format": "uri"
-                          },
-                          "description": "Contains the URI to the results."
-                      }
-                  }
+                "$ref": "#/components/responses/createdresponse"
               },
               "202": {
-                  "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                  "headers": {
-                      "Location": {
-                          "schema": {
-                              "type": "string",
-                              "format": "uri"
-                          },
-                          "description": "Contains a URI to query creation status."
-                      }
-                  }
+                "$ref": "#/components/responses/acceptedresponse"
               },
               "default": {
-                  "description": "The response contains a set of batch results, which may include errors and warnings.",
-                  "content": {
-                      "application/json": {
-                          "schema": {
-                              "$ref": "#/components/schemas/batchResults"
-                          }
-                      }
-                  }
+                "$ref": "#/components/responses/batchdefault"
               }
           }
       }    
@@ -1173,6 +1162,9 @@
               },
               {
                   "$ref": "#/components/parameters/location-id"
+              },
+              {
+                "$ref": "#/components/parameters/X-ADE-AcceptVersion"
               }
           ],
           "requestBody": {
@@ -1189,6 +1181,11 @@
           "responses": {
               "200": {
                   "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                  "headers": {
+                    "X-ADE-Version": {
+                      "$ref": "#/components/headers/X-ADE-Version"
+                    }
+                  },
                   "content": {
                       "application/json": {
                           "schema": {
@@ -1198,38 +1195,13 @@
                   }
               },
               "201": {
-                  "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                  "headers": {
-                      "Location": {
-                          "schema": {
-                              "type": "string",
-                              "format": "uri"
-                          },
-                          "description": "Contains the URI to the results."
-                      }
-                  }
+                "$ref": "#/components/responses/createdresponse"
               },
               "202": {
-                  "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                  "headers": {
-                      "Location": {
-                          "schema": {
-                              "type": "string",
-                              "format": "uri"
-                          },
-                          "description": "Contains a URI to query creation status."
-                      }
-                  }
+                "$ref": "#/components/responses/acceptedresponse"
               },
               "default": {
-                  "description": "The response contains a set of batch results, which may include errors and warnings.",
-                  "content": {
-                      "application/json": {
-                          "schema": {
-                              "$ref": "#/components/schemas/batchResults"
-                          }
-                      }
-                  }
+                "$ref": "#/components/responses/batchdefault"
               }
           }
       }    
@@ -1328,7 +1300,24 @@
         }
       }
     },
+    "headers": {
+      "X-ADE-Version": {
+        "description": "The version of the ADE specification.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    },
     "parameters": {
+      "X-ADE-AcceptVersion": {
+        "name": "X-ADE-AcceptVersion",
+        "in": "header",
+        "description": "The version of the ADE specification that the client accepts.",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
       "location-scheme": {
         "name": "location-scheme",
         "in": "path",
@@ -1423,6 +1412,11 @@
     "responses": {
       "default": {
         "description": "An error has occured while handling the request. Check the content of the message for the error details.",
+        "headers": {
+          "X-ADE-Version": {
+            "$ref": "#/components/headers/X-ADE-Version"
+          }
+        },
         "content": {
           "application/json": {
             "schema": {
@@ -1430,6 +1424,52 @@
             }
           }
         }
+      },
+      "batchdefault":
+      {
+        "description": "The response contains a set of batch results, which may include errors and warnings.",
+        "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/batchResults"
+            }
+          }
+        }
+      },
+      "createdresponse": {
+          "description": "Created. The Location header contains the URI to the new resource.",
+          "headers": {
+              "Location": {
+                  "schema": {
+                      "type": "string",
+                      "format": "uri"
+                  },
+                  "description": "Contains the URI to the new resource."
+              },
+              "X-ADE-Version": {
+                  "$ref": "#/components/headers/X-ADE-Version"
+              }
+          }
+      },
+      "acceptedresponse": {
+          "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
+          "headers": {
+              "Location": {
+                  "schema": {
+                      "type": "string",
+                      "format": "uri"
+                  },
+                  "description": "Contains a URI to query creation status."
+              },
+              "X-ADE-Version": {
+                  "$ref": "#/components/headers/X-ADE-Version"
+              }
+          }
       }
     }
   }

--- a/url-schemes/healthURLScheme.json
+++ b/url-schemes/healthURLScheme.json
@@ -87,6 +87,9 @@
           },
           {
             "$ref": "#/components/parameters/location-id"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "requestBody": {

--- a/url-schemes/managementURLScheme.json
+++ b/url-schemes/managementURLScheme.json
@@ -287,6 +287,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {

--- a/url-schemes/managementURLScheme.json
+++ b/url-schemes/managementURLScheme.json
@@ -42,11 +42,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/meta-modified-to"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the resources for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -73,6 +81,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -89,6 +100,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -98,28 +114,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -147,11 +145,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/meta-modified-to"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the resources for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -178,6 +184,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -194,6 +203,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -203,28 +217,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -252,11 +248,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/meta-modified-to"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the resources for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -299,6 +303,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -308,28 +317,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -357,11 +348,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/meta-modified-to"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the resources for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -388,6 +387,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -404,6 +406,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -413,28 +420,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -465,11 +454,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/purpose"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the statistics for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -519,6 +516,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/meta-modified-to"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
@@ -570,11 +570,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/meta-modified-to"
-                    }
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
+                    }                
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the medicine inventory transactions for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -621,11 +629,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/meta-modified-to"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the animal position observation events for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -652,6 +668,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -668,6 +687,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -677,28 +701,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -738,11 +744,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/meta-modified-to"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the animal position observation events for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -769,6 +783,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -785,6 +802,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -794,28 +816,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -855,11 +859,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/meta-modified-to"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the remark events for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -886,6 +898,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -902,6 +917,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modified by the server.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -911,28 +931,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -981,11 +983,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/meta-modified-to"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the animal observation summary resources for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1012,6 +1022,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -1028,6 +1041,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the resource, as modified by the server.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1037,28 +1055,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -1080,11 +1080,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the supported schemata for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1116,11 +1124,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/scheme-type"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the supported schemes for the specified scheme type for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1155,11 +1171,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/scheme"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the supported scheme values for the specified scheme and scheme type for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1182,9 +1206,19 @@
                 "tags": [
                     "ADE-1.5-management"
                 ],
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the supported schemata.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1210,11 +1244,19 @@
                 "parameters": [
                     {
                         "$ref": "#/components/parameters/scheme-type"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the supported schemes for the specified scheme type.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1243,11 +1285,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/scheme"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the values for the specified scheme and scheme type.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1282,11 +1332,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/meta-modified-to"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the resources for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1313,6 +1371,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -1329,6 +1390,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modified by the server.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1338,28 +1404,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -1387,11 +1435,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/meta-modified-to"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the resources for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1418,6 +1474,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -1434,6 +1493,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modified by the server.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1443,28 +1507,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -1486,6 +1532,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -1502,6 +1551,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1511,38 +1565,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -1561,6 +1590,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -1577,6 +1609,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1586,38 +1623,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -1636,6 +1648,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -1652,6 +1667,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1661,38 +1681,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -1711,6 +1706,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -1727,6 +1725,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1736,38 +1739,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -1786,6 +1764,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -1802,6 +1783,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1811,38 +1797,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -1861,6 +1822,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -1877,6 +1841,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1886,38 +1855,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -1936,6 +1880,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -1952,6 +1899,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1961,38 +1913,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -2011,6 +1938,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -2027,6 +1957,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2036,38 +1971,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -2086,6 +1996,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -2102,6 +2015,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2111,38 +2029,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -2161,6 +2054,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -2177,6 +2073,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2186,38 +2087,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -2236,6 +2112,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -2252,6 +2131,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2261,38 +2145,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -2311,6 +2170,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -2327,6 +2189,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2336,38 +2203,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -2386,6 +2228,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -2402,6 +2247,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2411,38 +2261,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -2521,9 +2346,6 @@
             },
             "icarFeedTransactionResource": {
                 "$ref": "../resources/icarFeedTransactionResource.json"
-            },
-            "icarFeedTransactionCollection": {
-                "$ref": "../collections/icarFeedTransactionCollection.json"
             },
             "icarFeedTransactionArray": {
                 "type": "array",
@@ -2622,7 +2444,24 @@
                 }
             }
         },
+        "headers": {
+            "X-ADE-Version": {
+                "description": "The version of the ADE specification.",
+                "schema": {
+                    "type": "string"
+                }
+            }
+        },
         "parameters": {
+            "X-ADE-AcceptVersion": {
+                "name": "X-ADE-AcceptVersion",
+                "in": "header",
+                "description": "The version of the ADE specification that the client accepts.",
+                "required": false,
+                "schema": {
+                    "type": "string"
+                }
+            },
             "location-scheme": {
                 "name": "location-scheme",
                 "in": "path",
@@ -2780,11 +2619,61 @@
         "responses": {
             "default": {
                 "description": "An error has occured while handling the request. Check the content of the message for the error details.",
+                "headers": {
+                    "X-ADE-Version": {
+                        "$ref": "#/components/headers/X-ADE-Version"
+                    }
+                },
                 "content": {
                     "application/json": {
                         "schema": {
                             "$ref": "../collections/icarErrorCollection.json"
                         }
+                    }
+                }
+            },
+            "batchdefault": {
+                "description": "The response contains a set of batch results, which may include errors and warnings.",
+                "headers": {
+                    "X-ADE-Version": {
+                        "$ref": "#/components/headers/X-ADE-Version"
+                    }
+                },
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/batchResults"
+                        }
+                    }
+                }
+            },
+            "createdresponse": {
+                "description": "Created. The Location header contains the URI to the new resource.",
+                "headers": {
+                    "Location": {
+                        "schema": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "description": "Contains the URI to the new resource."
+                    },
+                    "X-ADE-Version": {
+                        "$ref": "#/components/headers/X-ADE-Version"
+                    }
+                }
+            },
+            "acceptedresponse": {
+                "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
+                "headers": {
+                    "Location": {
+                        "schema": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "description": "Contains a URI to query creation status."
+                    },
+                    "X-ADE-Version": {
+                        "$ref": "#/components/headers/X-ADE-Version"
                     }
                 }
             }

--- a/url-schemes/milkURLScheme.json
+++ b/url-schemes/milkURLScheme.json
@@ -48,11 +48,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/animal-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
-                        "description": "Successful. The response contains the diagnoses for the given location.",
+                        "description": "Successful. The response contains the milking-visits for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -79,6 +87,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -95,6 +106,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -104,28 +120,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -159,11 +157,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/animal-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the diagnoses for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -190,6 +196,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -206,6 +215,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -215,28 +229,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -270,11 +266,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/animal-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the diagnoses for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -301,6 +305,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -317,6 +324,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -326,28 +338,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -381,11 +375,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/animal-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the diagnoses for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -426,11 +428,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/animal-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the milk predictions for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -465,11 +475,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/animal-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the diagnoses for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -510,11 +528,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/animal-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the diagnoses for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -541,6 +567,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -557,6 +586,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -566,28 +600,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -621,11 +637,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/animal-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the withdrawals for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -654,6 +678,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -670,6 +697,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -679,38 +711,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -729,6 +736,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -745,6 +755,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -754,38 +769,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -804,6 +794,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -820,6 +813,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -829,38 +827,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -879,6 +852,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -895,6 +871,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -904,38 +885,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -1010,7 +966,24 @@
                 "$ref": "../collections/icarWithdrawalEventCollection.json"
             }
         },
+        "headers": {
+            "X-ADE-Version": {
+                "description": "The version of the ADE specification.",
+                "schema": {
+                    "type": "string"
+                }
+            }
+        },
         "parameters": {
+            "X-ADE-AcceptVersion": {
+                "name": "X-ADE-AcceptVersion",
+                "in": "header",
+                "description": "The version of the ADE specification that the client accepts.",
+                "required": false,
+                "schema": {
+                    "type": "string"
+                }
+            },
             "location-scheme": {
                 "name": "location-scheme",
                 "in": "path",
@@ -1067,16 +1040,67 @@
             }
         },
         "responses": {
-          "default": {
-            "description": "An error has occured while handling the request. Check the content of the message for the error details.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "../collections/icarErrorCollection.json"
+            "default": {
+                "description": "An error has occured while handling the request. Check the content of the message for the error details.",
+                "headers": {
+                "X-ADE-Version": {
+                    "$ref": "#/components/headers/X-ADE-Version"
                 }
-              }
+                },
+                "content": {
+                "application/json": {
+                    "schema": {
+                    "$ref": "../collections/icarErrorCollection.json"
+                    }
+                }
+                }
+            },
+            "batchdefault":
+            {
+                "description": "The response contains a set of batch results, which may include errors and warnings.",
+                "headers": {
+                    "X-ADE-Version": {
+                        "$ref": "#/components/headers/X-ADE-Version"
+                    }
+                    },
+                "content": {
+                "application/json": {
+                    "schema": {
+                    "$ref": "#/components/schemas/batchResults"
+                    }
+                }
+                }
+            },
+            "createdresponse": {
+                "description": "Created. The Location header contains the URI to the new resource.",
+                "headers": {
+                    "Location": {
+                        "schema": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "description": "Contains the URI to the new resource."
+                    },
+                    "X-ADE-Version": {
+                        "$ref": "#/components/headers/X-ADE-Version"
+                    }
+                }
+            },
+            "acceptedresponse": {
+                "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
+                "headers": {
+                    "Location": {
+                        "schema": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "description": "Contains a URI to query creation status."
+                    },
+                    "X-ADE-Version": {
+                        "$ref": "#/components/headers/X-ADE-Version"
+                    }
+                }
             }
-          }
         }
     }
 }

--- a/url-schemes/performanceURLScheme.json
+++ b/url-schemes/performanceURLScheme.json
@@ -48,11 +48,22 @@
                     },
                     {
                         "$ref": "#/components/parameters/animal-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the resources for the given location.",
+                        "headers": {
+                            "X-ADE-AcceptVersion": {
+                                "description": "The version of the ADE accepted by the client.",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -79,6 +90,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -95,6 +109,14 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-AcceptVersion": {
+                                "description": "The version of the ADE accepted by the client.",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -104,28 +126,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -153,11 +157,22 @@
                     },
                     {
                         "$ref": "#/components/parameters/meta-modified-to"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the resources for the given location.",
+                        "headers": {
+                            "X-ADE-AcceptVersion": {
+                                "description": "The version of the ADE accepted by the client.",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -184,6 +199,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -200,6 +218,14 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-AcceptVersion": {
+                                "description": "The version of the ADE accepted by the client.",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -209,28 +235,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -264,11 +272,22 @@
                     },
                     {
                         "$ref": "#/components/parameters/animal-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the resources for the given location.",
+                        "headers": {
+                            "X-ADE-AcceptVersion": {
+                                "description": "The version of the ADE accepted by the client.",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -308,12 +327,23 @@
                         "$ref": "#/components/parameters/animal-scheme"
                     },
                     {
-                        "$ref": "#/components/parameters/animal-id"
+                    "$ref": "#/components/parameters/animal-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the resources for the given location.",
+                        "headers": {
+                            "X-ADE-AcceptVersion": {
+                                "description": "The version of the ADE accepted by the client.",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -340,6 +370,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -356,6 +389,14 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-AcceptVersion": {
+                                "description": "The version of the ADE accepted by the client.",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -365,28 +406,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -420,11 +443,22 @@
                     },
                     {
                         "$ref": "#/components/parameters/animal-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the resources for the given location.",
+                        "headers": {
+                            "X-ADE-AcceptVersion": {
+                                "description": "The version of the ADE accepted by the client.",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -451,6 +485,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -467,6 +504,14 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-AcceptVersion": {
+                                "description": "The version of the ADE accepted by the client.",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -476,28 +521,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -519,6 +546,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -535,6 +565,14 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-AcceptVersion": {
+                                "description": "The version of the ADE accepted by the client.",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -544,38 +582,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -594,6 +607,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -610,6 +626,14 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-AcceptVersion": {
+                                "description": "The version of the ADE accepted by the client.",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -619,38 +643,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -669,6 +668,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -685,6 +687,14 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-AcceptVersion": {
+                                "description": "The version of the ADE accepted by the client.",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -694,38 +704,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -785,7 +770,24 @@
                 }
             }
         },
+        "headers": {
+            "X-ADE-Version": {
+                "description": "The version of the ADE specification.",
+                "schema": {
+                    "type": "string"
+                }
+            }
+        },
         "parameters": {
+            "X-ADE-AcceptVersion": {
+                "name": "X-ADE-AcceptVersion",
+                "in": "header",
+                "description": "The version of the ADE specification that the client accepts.",
+                "required": false,
+                "schema": {
+                    "type": "string"
+                }
+            },
             "location-scheme": {
                 "name": "location-scheme",
                 "in": "path",
@@ -842,16 +844,67 @@
             }
         },
         "responses": {
-          "default": {
-            "description": "An error has occured while handling the request. Check the content of the message for the error details.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "../collections/icarErrorCollection.json"
+            "default": {
+                "description": "An error has occured while handling the request. Check the content of the message for the error details.",
+                "headers": {
+                    "X-ADE-Version": {
+                        "$ref": "#/components/headers/X-ADE-Version"
+                    }
+                },
+                "content": {
+                    "application/json": {
+                        "schema": {
+                        "$ref": "../collections/icarErrorCollection.json"
+                        }
+                    }
                 }
-              }
+            },
+            "batchdefault":
+            {
+                "description": "The response contains a set of batch results, which may include errors and warnings.",
+                "headers": {
+                    "X-ADE-Version": {
+                        "$ref": "#/components/headers/X-ADE-Version"
+                    }
+                },
+                "content": {
+                    "application/json": {
+                        "schema": {
+                        "$ref": "#/components/schemas/batchResults"
+                        }
+                    }
+                }
+            },
+            "createdresponse": {
+                "description": "Created. The Location header contains the URI to the new resource.",
+                "headers": {
+                    "Location": {
+                        "schema": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "description": "Contains the URI to the new resource."
+                    },
+                    "X-ADE-Version": {
+                        "$ref": "#/components/headers/X-ADE-Version"
+                    }
+                }
+            },
+            "acceptedresponse": {
+                "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
+                "headers": {
+                    "Location": {
+                        "schema": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "description": "Contains a URI to query creation status."
+                    },
+                    "X-ADE-Version": {
+                        "$ref": "#/components/headers/X-ADE-Version"
+                    }
+                }
             }
-          }
         }
     }
 }

--- a/url-schemes/performanceURLScheme.json
+++ b/url-schemes/performanceURLScheme.json
@@ -57,11 +57,8 @@
                     "200": {
                         "description": "Successful. The response contains the resources for the given location.",
                         "headers": {
-                            "X-ADE-AcceptVersion": {
-                                "description": "The version of the ADE accepted by the client.",
-                                "schema": {
-                                    "type": "string"
-                                }
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
                             }
                         },
                         "content": {

--- a/url-schemes/registrationURLScheme.json
+++ b/url-schemes/registrationURLScheme.json
@@ -85,11 +85,8 @@
                     "200": {
                         "description": "Successful. The response contains the animals for the given location",
                         "headers": {
-                            "X-ADE-AcceptVersion": {
-                                "description": "The version of the ADE accepted by the client",
-                                "schema": {
-                                    "type": "string"
-                                }
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
                             }
                         },
                         "content": {

--- a/url-schemes/registrationURLScheme.json
+++ b/url-schemes/registrationURLScheme.json
@@ -30,6 +30,11 @@
                 "tags": [
                     "ADE-1.5-registration"
                 ],
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the available locations.",
@@ -66,11 +71,22 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the animals for the given location",
+                        "headers": {
+                            "X-ADE-AcceptVersion": {
+                                "description": "The version of the ADE accepted by the client",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -97,6 +113,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -113,6 +132,14 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-AcceptVersion": {
+                                "description": "The version of the ADE accepted by the client",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -122,28 +149,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -177,11 +186,22 @@
                     },
                     {
                         "$ref": "#/components/parameters/animal-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the birth or initial registration events for the given location.",
+                        "headers": {
+                            "X-ADE-AcceptVersion": {
+                                "description": "The version of the ADE accepted by the client",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -208,6 +228,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -224,6 +247,14 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-AcceptVersion": {
+                                "description": "The version of the ADE accepted by the client",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -233,28 +264,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -282,11 +295,22 @@
                     },
                     {
                         "$ref": "#/components/parameters/meta-modified-to"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the birth or initial registration events for the given location.",
+                        "headers": {
+                            "X-ADE-AcceptVersion": {
+                                "description": "The version of the ADE accepted by the client",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -313,6 +337,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -329,6 +356,14 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-AcceptVersion": {
+                                "description": "The version of the ADE accepted by the client",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -338,28 +373,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -387,11 +404,22 @@
                     },
                     {
                         "$ref": "#/components/parameters/meta-modified-to"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the group death events for the given location.",
+                        "headers": {
+                            "X-ADE-AcceptVersion": {
+                                "description": "The version of the ADE accepted by the client",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -418,6 +446,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -434,6 +465,14 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-AcceptVersion": {
+                                "description": "The version of the ADE accepted by the client",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -443,28 +482,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -498,11 +519,22 @@
                     },
                     {
                         "$ref": "#/components/parameters/animal-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the death events for the given location.",
+                        "headers": {
+                            "X-ADE-AcceptVersion": {
+                                "description": "The version of the ADE accepted by the client",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -529,6 +561,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -545,6 +580,14 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-AcceptVersion": {
+                                "description": "The version of the ADE accepted by the client",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -554,28 +597,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -609,11 +634,22 @@
                     },
                     {
                         "$ref": "#/components/parameters/animal-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the arrival events for the given location.",
+                        "headers": {
+                            "X-ADE-AcceptVersion": {
+                                "description": "The version of the ADE accepted by the client",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -640,6 +676,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -656,6 +695,14 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-AcceptVersion": {
+                                "description": "The version of the ADE accepted by the client",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -665,28 +712,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -714,11 +743,22 @@
                     },
                     {
                         "$ref": "#/components/parameters/meta-modified-to"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the arrival events for the given location.",
+                        "headers": {
+                            "X-ADE-AcceptVersion": {
+                                "description": "The version of the ADE accepted by the client",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -745,6 +785,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -761,6 +804,14 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-AcceptVersion": {
+                                "description": "The version of the ADE accepted by the client",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -770,28 +821,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -825,11 +858,22 @@
                     },
                     {
                         "$ref": "#/components/parameters/animal-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the departure events for the given location.",
+                        "headers": {
+                            "X-ADE-AcceptVersion": {
+                                "description": "The version of the ADE accepted by the client",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -856,6 +900,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -872,6 +919,14 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-AcceptVersion": {
+                                "description": "The version of the ADE accepted by the client",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -881,28 +936,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -930,11 +967,22 @@
                     },
                     {
                         "$ref": "#/components/parameters/meta-modified-to"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the group departure events for the given location.",
+                        "headers": {
+                            "X-ADE-AcceptVersion": {
+                                "description": "The version of the ADE accepted by the client",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -961,6 +1009,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -977,6 +1028,14 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-AcceptVersion": {
+                                "description": "The version of the ADE accepted by the client",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -986,28 +1045,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -1029,6 +1070,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -1045,6 +1089,14 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-AcceptVersion": {
+                                "description": "The version of the ADE accepted by the client",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1054,38 +1106,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -1104,6 +1131,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -1120,6 +1150,14 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-AcceptVersion": {
+                                "description": "The version of the ADE accepted by the client",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1129,38 +1167,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -1179,6 +1192,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -1195,6 +1211,14 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-AcceptVersion": {
+                                "description": "The version of the ADE accepted by the client",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1204,38 +1228,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -1254,6 +1253,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -1270,6 +1272,14 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-AcceptVersion": {
+                                "description": "The version of the ADE accepted by the client",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1279,38 +1289,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -1329,6 +1314,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -1345,6 +1333,14 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-AcceptVersion": {
+                                "description": "The version of the ADE accepted by the client",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1354,38 +1350,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -1404,6 +1375,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -1420,6 +1394,14 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-AcceptVersion": {
+                                "description": "The version of the ADE accepted by the client",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1429,38 +1411,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -1479,6 +1436,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -1495,6 +1455,14 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-AcceptVersion": {
+                                "description": "The version of the ADE accepted by the client",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1504,38 +1472,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -1554,6 +1497,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -1570,6 +1516,14 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-AcceptVersion": {
+                                "description": "The version of the ADE accepted by the client",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1579,38 +1533,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -1629,6 +1558,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -1645,6 +1577,14 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-AcceptVersion": {
+                                "description": "The version of the ADE accepted by the client",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1654,38 +1594,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -1811,7 +1726,24 @@
                 }
             }
         },
+        "headers": {
+            "X-ADE-Version": {
+                "description": "The version of the ADE specification.",
+                "schema": {
+                    "type": "string"
+                }
+            }
+        },
         "parameters": {
+            "X-ADE-AcceptVersion": {
+                "name": "X-ADE-AcceptVersion",
+                "in": "header",
+                "description": "The version of the ADE specification that the client accepts.",
+                "required": false,
+                "schema": {
+                    "type": "string"
+                }
+            },
             "location-scheme": {
                 "name": "location-scheme",
                 "in": "path",
@@ -1895,16 +1827,67 @@
       }
     },        
         "responses": {
-          "default": {
-            "description": "An error has occured while handling the request. Check the content of the message for the error details.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "../collections/icarErrorCollection.json"
+            "default": {
+                "description": "An error has occured while handling the request. Check the content of the message for the error details.",
+                "headers": {
+                    "X-ADE-Version": {
+                        "$ref": "#/components/headers/X-ADE-Version"
+                    }
+                },
+                "content": {
+                    "application/json": {
+                        "schema": {
+                        "$ref": "../collections/icarErrorCollection.json"
+                        }
+                    }
                 }
-              }
+            },
+            "batchdefault":
+            {
+                "description": "The response contains a set of batch results, which may include errors and warnings.",
+                "headers": {
+                    "X-ADE-Version": {
+                        "$ref": "#/components/headers/X-ADE-Version"
+                    }
+                },
+                "content": {
+                    "application/json": {
+                        "schema": {
+                        "$ref": "#/components/schemas/batchResults"
+                        }
+                    }
+                }
+            },
+            "createdresponse": {
+                "description": "Created. The Location header contains the URI to the new resource.",
+                "headers": {
+                    "Location": {
+                        "schema": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "description": "Contains the URI to the new resource."
+                    },
+                    "X-ADE-Version": {
+                        "$ref": "#/components/headers/X-ADE-Version"
+                    }
+                }
+            },
+            "acceptedresponse": {
+                "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
+                "headers": {
+                    "Location": {
+                        "schema": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "description": "Contains a URI to query creation status."
+                    },
+                    "X-ADE-Version": {
+                        "$ref": "#/components/headers/X-ADE-Version"
+                    }
+                }
             }
-          }
         }
     }
 }

--- a/url-schemes/registrationURLScheme.json
+++ b/url-schemes/registrationURLScheme.json
@@ -38,6 +38,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the available locations.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/url-schemes/reproductionURLScheme.json
+++ b/url-schemes/reproductionURLScheme.json
@@ -48,11 +48,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/animal-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the events for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -79,6 +87,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -95,6 +106,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -104,28 +120,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -159,11 +157,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/animal-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the events for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -190,6 +196,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -206,6 +215,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -215,28 +229,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -270,11 +266,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/animal-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the resources for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -301,6 +305,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -317,6 +324,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -326,28 +338,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -381,11 +375,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/animal-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the events for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -412,6 +414,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -428,6 +433,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -437,28 +447,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -492,11 +484,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/animal-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the resources for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -523,6 +523,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -539,6 +542,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -548,28 +556,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -603,11 +593,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/animal-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the resources for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -634,6 +632,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -650,6 +651,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },  
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -659,28 +665,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -714,11 +702,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/animal-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the resources for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -745,6 +741,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -761,6 +760,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -770,28 +774,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -825,11 +811,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/animal-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the resources for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -856,6 +850,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -872,6 +869,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -881,28 +883,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -936,11 +920,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/animal-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the resources for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -967,6 +959,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -983,6 +978,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -992,28 +992,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -1047,11 +1029,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/animal-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the resources for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1078,6 +1068,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -1094,6 +1087,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1103,28 +1101,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -1158,11 +1138,19 @@
                     },
                     {
                         "$ref": "#/components/parameters/animal-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains the resources for the given location.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1189,6 +1177,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -1205,6 +1196,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a copy of the event, as modifed by the server.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1214,28 +1210,10 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains the URI to the new resource.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the new resource."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
                         "$ref": "#/components/responses/default"
@@ -1257,6 +1235,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -1273,6 +1254,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1282,38 +1268,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -1332,6 +1293,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -1348,6 +1312,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },                        
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1357,38 +1326,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -1407,6 +1351,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -1423,6 +1370,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1432,38 +1384,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -1482,6 +1409,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -1497,7 +1427,12 @@
                 },
                 "responses": {
                     "200": {
-                        "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "description": "Successful. The response contains a set of batch results, which may include warnings.",   
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1507,38 +1442,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -1557,6 +1467,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -1573,6 +1486,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1582,38 +1500,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -1632,6 +1525,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -1648,6 +1544,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1657,38 +1558,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -1707,6 +1583,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -1723,6 +1602,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1732,38 +1616,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -1782,6 +1641,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -1798,6 +1660,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1807,38 +1674,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -1857,6 +1699,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -1873,6 +1718,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1882,38 +1732,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -1932,6 +1757,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -1948,6 +1776,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1957,38 +1790,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -2007,6 +1815,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/location-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/X-ADE-AcceptVersion"
                     }
                 ],
                 "requestBody": {
@@ -2023,6 +1834,11 @@
                 "responses": {
                     "200": {
                         "description": "Successful. The response contains a set of batch results, which may include warnings.",
+                        "headers": {
+                            "X-ADE-Version": {
+                                "$ref": "#/components/headers/X-ADE-Version"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2032,38 +1848,13 @@
                         }
                     },
                     "201": {
-                        "description": "Created. The Location header contains URI to retrieve a set of batch results, which may include warnings.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains the URI to the results."
-                            }
-                        }
+                        "$ref": "#/components/responses/createdresponse"
                     },
                     "202": {
-                        "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "Contains a URI to query creation status."
-                            }
-                        }
+                        "$ref": "#/components/responses/acceptedresponse"
                     },
                     "default": {
-                        "description": "The response contains a set of batch results, which may include errors and warnings.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/batchResults"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/batchdefault"
                     }
                 }
             }
@@ -2210,7 +2001,24 @@
                 }
             }
         },
+        "headers": {
+            "X-ADE-Version": {
+                "description": "The version of the ADE specification.",
+                "schema": {
+                    "type": "string"
+                }
+            }
+        },
         "parameters": {
+            "X-ADE-AcceptVersion": {
+                "name": "X-ADE-AcceptVersion",
+                "in": "header",
+                "description": "The version of the ADE specification that the client accepts.",
+                "required": false,
+                "schema": {
+                    "type": "string"
+                }
+            },
             "location-scheme": {
                 "name": "location-scheme",
                 "in": "path",
@@ -2267,16 +2075,71 @@
             }
         },
         "responses": {
-          "default": {
-            "description": "An error has occured while handling the request. Check the content of the message for the error details.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "../collections/icarErrorCollection.json"
+            "default": {
+                "description": "An error has occured while handling the request. Check the content of the message for the error details.",
+                "headers": {
+                "X-ADE-AcceptVersion": {
+                    "description": "The version of the API to accept.",
+                    "schema": {
+                    "type": "string"
+                    }
                 }
-              }
+                },
+                "content": {
+                "application/json": {
+                    "schema": {
+                    "$ref": "../collections/icarErrorCollection.json"
+                    }
+                }
+                }
+            },
+            "batchdefault":
+            {
+                "description": "The response contains a set of batch results, which may include errors and warnings.",
+                "headers": {
+                    "X-ADE-Version": {
+                        "$ref": "#/components/headers/X-ADE-Version"
+                    }
+                    },
+                "content": {
+                "application/json": {
+                    "schema": {
+                    "$ref": "#/components/schemas/batchResults"
+                    }
+                }
+                }
+            },
+            "createdresponse": {
+                "description": "Created. The Location header contains the URI to the new resource.",
+                "headers": {
+                    "Location": {
+                        "schema": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "description": "Contains the URI to the new resource."
+                    },
+                    "X-ADE-Version": {
+                        "$ref": "#/components/headers/X-ADE-Version"
+                    }
+                }
+            },
+            "acceptedresponse": {
+                "description": "Accepted. The Location header contains a URI that the client can query for processing status.",
+                "headers": {
+                    "Location": {
+                        "schema": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "description": "Contains a URI to query creation status."
+                    },
+                    "X-ADE-Version": {
+                        "$ref": "#/components/headers/X-ADE-Version"
+                    }
+                }
             }
-          }
+
         }
     }
 }

--- a/url-schemes/reproductionURLScheme.json
+++ b/url-schemes/reproductionURLScheme.json
@@ -2083,11 +2083,11 @@
                     }
                 },
                 "content": {
-                "application/json": {
-                    "schema": {
-                    "$ref": "../collections/icarErrorCollection.json"
+                    "application/json": {
+                        "schema": {
+                        "$ref": "../collections/icarErrorCollection.json"
+                        }
                     }
-                }
                 }
             },
             "batchdefault":

--- a/url-schemes/reproductionURLScheme.json
+++ b/url-schemes/reproductionURLScheme.json
@@ -2078,12 +2078,9 @@
             "default": {
                 "description": "An error has occured while handling the request. Check the content of the message for the error details.",
                 "headers": {
-                "X-ADE-AcceptVersion": {
-                    "description": "The version of the API to accept.",
-                    "schema": {
-                    "type": "string"
+                    "X-ADE-Version": {
+                        "$ref": "#/components/headers/X-ADE-Version"
                     }
-                }
                 },
                 "content": {
                 "application/json": {
@@ -2100,7 +2097,7 @@
                     "X-ADE-Version": {
                         "$ref": "#/components/headers/X-ADE-Version"
                     }
-                    },
+                },
                 "content": {
                 "application/json": {
                     "schema": {

--- a/url-schemes/sortingURLScheme.json
+++ b/url-schemes/sortingURLScheme.json
@@ -36,11 +36,19 @@
           },
           {
             "$ref": "#/components/parameters/location-id"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the resources for the given location.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -75,11 +83,19 @@
           },
           {
             "$ref": "#/components/parameters/animal-id"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the resources for the given location.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -112,11 +128,19 @@
           },
           {
             "$ref": "#/components/parameters/animal-id"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
-            "description": "Successful."
+            "description": "Successful.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            }
           },
           "default": {
             "$ref": "#/components/responses/default"
@@ -138,11 +162,19 @@
           },
           {
             "$ref": "#/components/parameters/location-id"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "responses": {
           "200": {
             "description": "Successful. The response contains the resources for the given location.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -169,6 +201,9 @@
           },
           {
             "$ref": "#/components/parameters/location-id"
+          },
+          {
+            "$ref": "#/components/parameters/X-ADE-AcceptVersion"
           }
         ],
         "requestBody": {
@@ -185,6 +220,11 @@
         "responses": {
           "200": {
             "description": "Successful. The response contains a copy of the event, as modified by the server.",
+            "headers": {
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -202,6 +242,9 @@
                   "format": "uri"
                 },
                 "description": "Contains the URI to the new resource."
+              },
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
               }
             }
           },
@@ -214,6 +257,9 @@
                   "format": "uri"
                 },
                 "description": "Contains a URI to query creation status."
+              },
+              "X-ADE-Version": {
+                "$ref": "#/components/headers/X-ADE-Version"
               }
             }
           },
@@ -237,6 +283,14 @@
       },
       "icarAnimalSortingCommandResource": {
         "$ref": "../resources/icarAnimalSortingCommandResource.json"
+      }
+    },
+    "headers": {
+      "X-ADE-Version": {
+        "description": "The version of the ADE specification.",
+        "schema": {
+          "type": "string"
+        }
       }
     },
     "parameters": {
@@ -275,11 +329,25 @@
         "schema": {
           "type": "string"
         }
+      },
+      "X-ADE-AcceptVersion": {
+        "name": "X-ADE-AcceptVersion",
+        "in": "header",
+        "description": "The version of the ADE specification that the client accepts.",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
       }
     },
     "responses": {
       "default": {
         "description": "An error has occured while handling the request. Check the content of the message for the error details.",
+        "headers": {
+          "X-ADE-Version": {
+            "$ref": "#/components/headers/X-ADE-Version"
+          }
+        },
         "content": {
           "application/json": {
             "schema": {


### PR DESCRIPTION
Add the `X-ADE-Version` header to all responses in all OpenAPI scheme files (in `/url-schemes`).
Add the optional `X-ADE-AcceptVersion` header to all request parameters in the OpenAPI files.

Along the way, I noticed a couple of errors (an unused `icarFeedInventoryCollection` in the management schemes, an incorrect comment on `milking-visit` in the milking url schemes so corrected these.

There was a lot of duplication of batch error responses, 201 created and 202 accepted responses, so where I could I added these definitions to `#components/responses` and simplified the individual endpoint definitions.

I know this will be hard to review because of the size of the OpenAPI files, so I will also ask CoPilot to review.