### PR TITLE
Add Milking Visit detachTime and additional remark enumerated values.

### DIFF
--- a/enums/icarMilkingRemarksType.json
+++ b/enums/icarMilkingRemarksType.json
@@ -9,7 +9,7 @@
     "TeatSeparated",
     "MilkedSeparately",
     "SamplingFailed",
-    "ManuallyIdenfied",
+    "ManuallyIdentified",
     "ManuallyDetached",
     "Reattached"
   ]

--- a/enums/icarMilkingRemarksType.json
+++ b/enums/icarMilkingRemarksType.json
@@ -8,6 +8,9 @@
     "MilkingIncomplete",
     "TeatSeparated",
     "MilkedSeparately",
-    "SamplingFailed"
+    "SamplingFailed",
+    "ManuallyIdenfied",
+    "ManuallyDetached",
+    "Reattached"
   ]
 }

--- a/resources/icarMilkingVisitEventResource.json
+++ b/resources/icarMilkingVisitEventResource.json
@@ -92,7 +92,7 @@
         },
         "detachTime": {
           "$ref": "../types/icarDateTimeType.json",
-          "description": "The RFC3339 UTC date and time when the milking unit was detached."
+          "description": "The RFC3339 UTC date and time when the cluster or milking unit was detached."
         }
       }
     }

--- a/resources/icarMilkingVisitEventResource.json
+++ b/resources/icarMilkingVisitEventResource.json
@@ -89,6 +89,10 @@
           "items": {
             "$ref": "../enums/icarMilkingRemarksType.json"
           }
+        },
+        "detachTime": {
+          "$ref": "../types/icarDateTimeType.json",
+          "description": "The RFC3339 UTC date and time when the milking unit was detached."
         }
       }
     }


### PR DESCRIPTION
Add new `icarMilkingRemarksType` enumerated values:
* ManuallyIdentified - the user had to manually identify the animal as its electronic identification was not read.
* ManullyDetached - the user manually detached the cluster or milking unit
* Reattached - the cluster or milking unit was detached and reattached.

Add `detachTime` to `icarMilkingVisitEventResource`.

Resolves #629 